### PR TITLE
fix mkdir in package.json

### DIFF
--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
-        "package": "shx mkdir -p lib/cjs && shx mkdir -p lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
+        "package": "shx mkdir -p lib/cjs lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
         "prebuild": "pnpm run clean && pnpm run package"
     },
     "dependencies": {

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
-        "package": "shx mkdir -p lib/{cjs,esm} && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
+        "package": "shx mkdir -p lib/cjs && shx mkdir -p lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
         "prebuild": "pnpm run clean && pnpm run package"
     },
     "dependencies": {

--- a/packages/core/standard/package.json
+++ b/packages/core/standard/package.json
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
-        "package": "shx mkdir -p lib/cjs && shx mkdir -p lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
+        "package": "shx mkdir -p lib/cjs lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
         "prebuild": "pnpm run clean && pnpm run package"
     },
     "devDependencies": {

--- a/packages/core/standard/package.json
+++ b/packages/core/standard/package.json
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
-        "package": "shx mkdir -p lib/{cjs,esm} && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
+        "package": "shx mkdir -p lib/cjs && shx mkdir -p lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
         "prebuild": "pnpm run clean && pnpm run package"
     },
     "devDependencies": {

--- a/packages/example/react/package.json
+++ b/packages/example/react/package.json
@@ -6,7 +6,7 @@
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",
     "scripts": {
-        "clean": "shx mkdir -p {dist,.parcel-cache} && shx rm -rf dist .parcel-cache",
+        "clean": "shx mkdir -p dist && shx mkdir -p .parcel-cache && shx rm -rf dist .parcel-cache",
         "start": "yarn clean && parcel src/index.html",
         "build": "yarn clean && parcel build src/index.html",
         "prebuild": "pnpm run clean"

--- a/packages/example/react/package.json
+++ b/packages/example/react/package.json
@@ -6,7 +6,7 @@
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",
     "scripts": {
-        "clean": "shx mkdir -p dist && shx mkdir -p .parcel-cache && shx rm -rf dist .parcel-cache",
+        "clean": "shx mkdir -p dist .parcel-cache && shx rm -rf dist .parcel-cache",
         "start": "yarn clean && parcel src/index.html",
         "build": "yarn clean && parcel build src/index.html",
         "prebuild": "pnpm run clean"

--- a/packages/example/wallets/package.json
+++ b/packages/example/wallets/package.json
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
-        "package": "shx mkdir -p lib/cjs && shx mkdir -p lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
+        "package": "shx mkdir -p lib/cjs lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
         "prebuild": "pnpm run clean && pnpm run package"
     },
     "dependencies": {

--- a/packages/example/wallets/package.json
+++ b/packages/example/wallets/package.json
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
-        "package": "shx mkdir -p lib/{cjs,esm} && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
+        "package": "shx mkdir -p lib/cjs && shx mkdir -p lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
         "prebuild": "pnpm run clean && pnpm run package"
     },
     "dependencies": {

--- a/packages/solana/wallet-adapter/package.json
+++ b/packages/solana/wallet-adapter/package.json
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
-        "package": "shx mkdir -p lib/cjs && shx mkdir -p lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
+        "package": "shx mkdir -p lib/cjs lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
         "prebuild": "pnpm run clean && pnpm run package"
     },
     "dependencies": {

--- a/packages/solana/wallet-adapter/package.json
+++ b/packages/solana/wallet-adapter/package.json
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
-        "package": "shx mkdir -p lib/{cjs,esm} && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
+        "package": "shx mkdir -p lib/cjs && shx mkdir -p lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
         "prebuild": "pnpm run clean && pnpm run package"
     },
     "dependencies": {


### PR DESCRIPTION
**Issue**
The package does not build as expected using Ubuntu 22.04 - the command `shx mkdir -p lib/{cjs,esm}` in package.json creates one folder lib/{cjs,esm} rather than two folders as expected. This issue is consistent across npm, pnpm, and yarn.
This PR is related to [typescript-monorepo #1](https://github.com/jordansexton/typescript-monorepo/pull/1).

**Fix**
Extended scripts to specify unique paths.