### PR TITLE
Optimize standard wallet adapter wrapping

### DIFF
--- a/packages/_/_/package.json
+++ b/packages/_/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/example/wallet-adapter-react/next.config.js
+++ b/packages/example/wallet-adapter-react/next.config.js
@@ -18,7 +18,6 @@ module.exports = function (phase, ...args) {
         ],
         {
             reactStrictMode: true,
-            basePath: phase === PHASE_PRODUCTION_BUILD ? '/wallet-adapter/example' : '',
         }
     )(phase, ...args);
 };

--- a/packages/wallet-adapter/_/package.json
+++ b/packages/wallet-adapter/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/react/package.json
+++ b/packages/wallet-adapter/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter-react",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",


### PR DESCRIPTION
The `useStandardWalletAdapters` hook is inefficient, triggering a render from `useEffect` on the initial render. This causes an app using this to initially render without the wrapped standard wallets, having a tendency to mess with logic that auto-selects a wallet. The filtering of the adapters provided is also inefficient, filtering standard adapters against each other by name, iterating over adapters too many times, and also causing later-registered wallets to end up in the output before first-registered ones. This fixes these things by using refs and memos and splitting the adapters into separate queues.