### PR TITLE
Use latest @solana/wallet-adapter-base, export reusable feature names

### DIFF
--- a/.changeset/sixty-shrimps-notice.md
+++ b/.changeset/sixty-shrimps-notice.md
@@ -1,0 +1,7 @@
+---
+'@solana/wallet-standard-wallet-adapter-react': patch
+'@solana/wallet-standard-wallet-adapter-base': patch
+'@solana/wallet-standard-features': patch
+---
+
+Use latest @solana/wallet-adapter-base, export reusable feature names

--- a/packages/core/_/package.json
+++ b/packages/core/_/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@solana/wallet-standard-chains": "workspace:^",
-        "@solana/wallet-standard-features": "workspace:^",
+        "@solana/wallet-standard-features": "^1.0.1",
         "@solana/wallet-standard-util": "workspace:^"
     },
     "devDependencies": {

--- a/packages/core/chains/package.json
+++ b/packages/core/chains/package.json
@@ -30,7 +30,7 @@
         "package": "shx mkdir -p lib/cjs && shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json"
     },
     "dependencies": {
-        "@wallet-standard/base": "^1.0.0"
+        "@wallet-standard/base": "^1.0.1"
     },
     "devDependencies": {
         "shx": "^0.3.4"

--- a/packages/core/chains/src/index.ts
+++ b/packages/core/chains/src/index.ts
@@ -21,7 +21,7 @@ export const SOLANA_CHAINS = [
 ] as const;
 
 /** Type of all Solana clusters */
-export type SolanaChain = typeof SOLANA_CHAINS[number];
+export type SolanaChain = (typeof SOLANA_CHAINS)[number];
 
 /**
  * Check if a chain corresponds with one of the Solana clusters.

--- a/packages/core/features/package.json
+++ b/packages/core/features/package.json
@@ -30,8 +30,8 @@
         "package": "shx mkdir -p lib/cjs && shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json"
     },
     "dependencies": {
-        "@wallet-standard/base": "^1.0.0",
-        "@wallet-standard/features": "^1.0.0"
+        "@wallet-standard/base": "^1.0.1",
+        "@wallet-standard/features": "^1.0.3"
     },
     "devDependencies": {
         "shx": "^0.3.4"

--- a/packages/core/features/package.json
+++ b/packages/core/features/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-features",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/features/src/signAndSendTransaction.ts
+++ b/packages/core/features/src/signAndSendTransaction.ts
@@ -11,13 +11,13 @@ export const SolanaSignAndSendTransaction = 'solana:signAndSendTransaction';
 
 /** TODO: docs */
 export type SolanaSignAndSendTransactionFeature = {
-    /** Namespace for the feature. */
-    'solana:signAndSendTransaction': {
+    /** Name of the feature. */
+    readonly [SolanaSignAndSendTransaction]: {
         /** Version of the feature API. */
-        version: SolanaSignAndSendTransactionVersion;
+        readonly version: SolanaSignAndSendTransactionVersion;
 
         /** TODO: docs */
-        supportedTransactionVersions: ReadonlyArray<SolanaTransactionVersion>;
+        readonly supportedTransactionVersions: ReadonlyArray<SolanaTransactionVersion>;
 
         /**
          * Sign transactions using the account's secret key and send them to the chain.
@@ -26,7 +26,7 @@ export type SolanaSignAndSendTransactionFeature = {
          *
          * @return Outputs of signing and sending transactions.
          */
-        signAndSendTransaction: SolanaSignAndSendTransactionMethod;
+        readonly signAndSendTransaction: SolanaSignAndSendTransactionMethod;
     };
 };
 
@@ -35,30 +35,30 @@ export type SolanaSignAndSendTransactionVersion = '1.0.0';
 
 /** TODO: docs */
 export type SolanaSignAndSendTransactionMethod = (
-    ...inputs: SolanaSignAndSendTransactionInput[]
-) => Promise<SolanaSignAndSendTransactionOutput[]>;
+    ...inputs: readonly SolanaSignAndSendTransactionInput[]
+) => Promise<readonly SolanaSignAndSendTransactionOutput[]>;
 
 /** Input for signing and sending a transaction. */
 export interface SolanaSignAndSendTransactionInput extends SolanaSignTransactionInput {
     /** Chain to use. */
-    chain: IdentifierString;
+    readonly chain: IdentifierString;
 
     /** TODO: docs */
-    options?: SolanaSignAndSendTransactionOptions;
+    readonly options?: SolanaSignAndSendTransactionOptions;
 }
 
 /** Output of signing and sending a transaction. */
 export interface SolanaSignAndSendTransactionOutput {
     /** Transaction signature, as raw bytes. */
-    signature: Uint8Array;
+    readonly signature: Uint8Array;
 }
 
 /** Options for signing and sending a transaction. */
 export type SolanaSignAndSendTransactionOptions = SolanaSignTransactionOptions & {
     /** Desired commitment level. If provided, confirm the transaction after sending. */
-    commitment?: SolanaTransactionCommitment;
+    readonly commitment?: SolanaTransactionCommitment;
     /** Disable transaction verification at the RPC. */
-    skipPreflight?: boolean;
+    readonly skipPreflight?: boolean;
     /** Maximum number of times for the RPC node to retry sending the transaction to the leader. */
-    maxRetries?: number;
+    readonly maxRetries?: number;
 };

--- a/packages/core/features/src/signAndSendTransaction.ts
+++ b/packages/core/features/src/signAndSendTransaction.ts
@@ -17,7 +17,7 @@ export type SolanaSignAndSendTransactionFeature = {
         readonly version: SolanaSignAndSendTransactionVersion;
 
         /** TODO: docs */
-        readonly supportedTransactionVersions: ReadonlyArray<SolanaTransactionVersion>;
+        readonly supportedTransactionVersions: readonly SolanaTransactionVersion[];
 
         /**
          * Sign transactions using the account's secret key and send them to the chain.
@@ -57,8 +57,10 @@ export interface SolanaSignAndSendTransactionOutput {
 export type SolanaSignAndSendTransactionOptions = SolanaSignTransactionOptions & {
     /** Desired commitment level. If provided, confirm the transaction after sending. */
     readonly commitment?: SolanaTransactionCommitment;
+
     /** Disable transaction verification at the RPC. */
     readonly skipPreflight?: boolean;
+
     /** Maximum number of times for the RPC node to retry sending the transaction to the leader. */
     readonly maxRetries?: number;
 };

--- a/packages/core/features/src/signAndSendTransaction.ts
+++ b/packages/core/features/src/signAndSendTransaction.ts
@@ -6,6 +6,9 @@ import type {
     SolanaTransactionVersion,
 } from './signTransaction.js';
 
+/** Name of the feature. */
+export const SolanaSignAndSendTransaction = 'solana:signAndSendTransaction';
+
 /** TODO: docs */
 export type SolanaSignAndSendTransactionFeature = {
     /** Namespace for the feature. */

--- a/packages/core/features/src/signMessage.ts
+++ b/packages/core/features/src/signMessage.ts
@@ -5,13 +5,13 @@ export const SolanaSignMessage = 'solana:signMessage';
 
 /** TODO: docs */
 export type SolanaSignMessageFeature = {
-    /** Namespace for the feature. */
-    'solana:signMessage': {
+    /** Name of the feature. */
+    readonly [SolanaSignMessage]: {
         /** Version of the feature API. */
-        version: SolanaSignMessageVersion;
+        readonly version: SolanaSignMessageVersion;
 
         /** Sign messages (arbitrary bytes) using the account's secret key. */
-        signMessage: SolanaSignMessageMethod;
+        readonly signMessage: SolanaSignMessageMethod;
     };
 };
 
@@ -19,22 +19,24 @@ export type SolanaSignMessageFeature = {
 export type SolanaSignMessageVersion = '1.0.0';
 
 /** TODO: docs */
-export type SolanaSignMessageMethod = (...inputs: SolanaSignMessageInput[]) => Promise<SolanaSignMessageOutput[]>;
+export type SolanaSignMessageMethod = (
+    ...inputs: readonly SolanaSignMessageInput[]
+) => Promise<readonly SolanaSignMessageOutput[]>;
 
 /** Input for signing a message. */
 export interface SolanaSignMessageInput {
     /** Account to use. */
-    account: WalletAccount;
+    readonly account: WalletAccount;
 
     /** Message to sign, as raw bytes. */
-    message: Uint8Array;
+    readonly message: Uint8Array;
 }
 
 /** Output of signing a message. */
 export interface SolanaSignMessageOutput {
     /** TODO: docs */
-    signedMessage: Uint8Array;
+    readonly signedMessage: Uint8Array;
 
     /** TODO: docs */
-    signature: Uint8Array;
+    readonly signature: Uint8Array;
 }

--- a/packages/core/features/src/signMessage.ts
+++ b/packages/core/features/src/signMessage.ts
@@ -1,5 +1,8 @@
 import type { WalletAccount } from '@wallet-standard/base';
 
+/** Name of the feature. */
+export const SolanaSignMessage = 'solana:signMessage';
+
 /** TODO: docs */
 export type SolanaSignMessageFeature = {
     /** Namespace for the feature. */

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -11,7 +11,7 @@ export type SolanaSignTransactionFeature = {
         readonly version: SolanaSignTransactionVersion;
 
         /** TODO: docs */
-        readonly supportedTransactionVersions: ReadonlyArray<SolanaTransactionVersion>;
+        readonly supportedTransactionVersions: readonly SolanaTransactionVersion[];
 
         /**
          * Sign transactions using the account's secret key.
@@ -64,6 +64,7 @@ export interface SolanaSignTransactionOutput {
 export type SolanaSignTransactionOptions = {
     /** Preflight commitment level. */
     readonly preflightCommitment?: SolanaTransactionCommitment;
+
     /** The minimum slot that the request can be evaluated at. */
     readonly minContextSlot?: number;
 };

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -5,13 +5,13 @@ export const SolanaSignTransaction = 'solana:signTransaction';
 
 /** TODO: docs */
 export type SolanaSignTransactionFeature = {
-    /** Namespace for the feature. */
-    'solana:signTransaction': {
+    /** Name of the feature. */
+    readonly [SolanaSignTransaction]: {
         /** Version of the feature API. */
-        version: SolanaSignTransactionVersion;
+        readonly version: SolanaSignTransactionVersion;
 
         /** TODO: docs */
-        supportedTransactionVersions: ReadonlyArray<SolanaTransactionVersion>;
+        readonly supportedTransactionVersions: ReadonlyArray<SolanaTransactionVersion>;
 
         /**
          * Sign transactions using the account's secret key.
@@ -20,7 +20,7 @@ export type SolanaSignTransactionFeature = {
          *
          * @return Outputs of signing transactions.
          */
-        signTransaction: SolanaSignTransactionMethod;
+        readonly signTransaction: SolanaSignTransactionMethod;
     };
 };
 
@@ -32,22 +32,22 @@ export type SolanaTransactionVersion = 'legacy' | 0;
 
 /** TODO: docs */
 export type SolanaSignTransactionMethod = (
-    ...inputs: SolanaSignTransactionInput[]
-) => Promise<SolanaSignTransactionOutput[]>;
+    ...inputs: readonly SolanaSignTransactionInput[]
+) => Promise<readonly SolanaSignTransactionOutput[]>;
 
 /** Input for signing a transaction. */
 export interface SolanaSignTransactionInput {
     /** Account to use. */
-    account: WalletAccount;
+    readonly account: WalletAccount;
 
     /** Serialized transaction, as raw bytes. */
-    transaction: Uint8Array;
+    readonly transaction: Uint8Array;
 
     /** Chain to use. */
-    chain?: IdentifierString;
+    readonly chain?: IdentifierString;
 
     /** TODO: docs */
-    options?: SolanaSignTransactionOptions;
+    readonly options?: SolanaSignTransactionOptions;
 }
 
 /** Output of signing a transaction. */
@@ -57,15 +57,15 @@ export interface SolanaSignTransactionOutput {
      * Returning a transaction rather than signatures allows multisig wallets, program wallets, and other wallets that
      * use meta-transactions to return a modified, signed transaction.
      */
-    signedTransaction: Uint8Array;
+    readonly signedTransaction: Uint8Array;
 }
 
 /** Options for signing a transaction. */
 export type SolanaSignTransactionOptions = {
     /** Preflight commitment level. */
-    preflightCommitment?: SolanaTransactionCommitment;
+    readonly preflightCommitment?: SolanaTransactionCommitment;
     /** The minimum slot that the request can be evaluated at. */
-    minContextSlot?: number;
+    readonly minContextSlot?: number;
 };
 
 /** Commitment level for transactions. */

--- a/packages/core/features/src/signTransaction.ts
+++ b/packages/core/features/src/signTransaction.ts
@@ -1,5 +1,8 @@
 import type { IdentifierString, WalletAccount } from '@wallet-standard/base';
 
+/** Name of the feature. */
+export const SolanaSignTransaction = 'solana:signTransaction';
+
 /** TODO: docs */
 export type SolanaSignTransactionFeature = {
     /** Namespace for the feature. */

--- a/packages/core/util/package.json
+++ b/packages/core/util/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@solana/wallet-standard-chains": "workspace:^",
-        "@solana/wallet-standard-features": "workspace:^"
+        "@solana/wallet-standard-features": "^1.0.1"
     },
     "devDependencies": {
         "shx": "^0.3.4"

--- a/packages/wallet-adapter/base/package.json
+++ b/packages/wallet-adapter/base/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.21",
         "@solana/wallet-standard-chains": "workspace:^",
-        "@solana/wallet-standard-features": "workspace:^",
+        "@solana/wallet-standard-features": "^1.0.1",
         "@solana/wallet-standard-util": "workspace:^",
         "@wallet-standard/app": "^1.0.1",
         "@wallet-standard/base": "^1.0.1",

--- a/packages/wallet-adapter/base/package.json
+++ b/packages/wallet-adapter/base/package.json
@@ -38,10 +38,10 @@
         "@solana/wallet-standard-chains": "workspace:^",
         "@solana/wallet-standard-features": "workspace:^",
         "@solana/wallet-standard-util": "workspace:^",
-        "@wallet-standard/app": "^1.0.0",
-        "@wallet-standard/base": "^1.0.0",
-        "@wallet-standard/features": "^1.0.0",
-        "@wallet-standard/wallet": "^1.0.0"
+        "@wallet-standard/app": "^1.0.1",
+        "@wallet-standard/base": "^1.0.1",
+        "@wallet-standard/features": "^1.0.3",
+        "@wallet-standard/wallet": "^1.0.1"
     },
     "devDependencies": {
         "@solana/web3.js": "^1.58.0",

--- a/packages/wallet-adapter/base/package.json
+++ b/packages/wallet-adapter/base/package.json
@@ -34,7 +34,7 @@
         "bs58": "^4.0.1"
     },
     "dependencies": {
-        "@solana/wallet-adapter-base": "^0.9.18",
+        "@solana/wallet-adapter-base": "^0.9.21",
         "@solana/wallet-standard-chains": "workspace:^",
         "@solana/wallet-standard-features": "workspace:^",
         "@solana/wallet-standard-util": "workspace:^",

--- a/packages/wallet-adapter/base/src/adapter.ts
+++ b/packages/wallet-adapter/base/src/adapter.ts
@@ -1,11 +1,7 @@
-import type {
-    SendTransactionOptions,
-    SupportedTransactionVersions,
-    WalletAdapter,
-    WalletName,
-} from '@solana/wallet-adapter-base';
 import {
     BaseWalletAdapter,
+    isWalletAdapterCompatibleStandardWallet as isWalletAdapterCompatibleWallet,
+    isVersionedTransaction,
     WalletAccountError,
     WalletConfigError,
     WalletConnectionError,
@@ -28,39 +24,17 @@ import type {
 import { getChainForEndpoint, getCommitment } from '@solana/wallet-standard-util';
 import type { Connection, TransactionSignature } from '@solana/web3.js';
 import { PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
-import type { Wallet, WalletAccount, WalletWithFeatures } from '@wallet-standard/base';
-import type { ConnectFeature, DisconnectFeature, EventsFeature, EventsListeners } from '@wallet-standard/features';
+import type { WalletAccount } from '@wallet-standard/base';
+import type { EventsListeners } from '@wallet-standard/features';
 import { arraysEqual } from '@wallet-standard/wallet';
 import bs58 from 'bs58';
-import { isVersionedTransaction } from './transaction.js';
 
-/** TODO: docs */
-export type WalletAdapterCompatibleWallet = WalletWithFeatures<
-    ConnectFeature &
-        EventsFeature &
-        (SolanaSignAndSendTransactionFeature | SolanaSignTransactionFeature) &
-        (DisconnectFeature | SolanaSignMessageFeature | never)
->;
-
-/** TODO: docs */
-export function isWalletAdapterCompatibleWallet(wallet: Wallet): wallet is WalletAdapterCompatibleWallet {
-    return (
-        'standard:connect' in wallet.features &&
-        'standard:events' in wallet.features &&
-        ('solana:signAndSendTransaction' in wallet.features || 'solana:signTransaction' in wallet.features)
-    );
-}
+export { StandardAdapter, WalletAdapterCompatibleWallet, isWalletAdapterCompatibleWallet };
 
 /** TODO: docs */
 export interface StandardWalletAdapterConfig {
     wallet: WalletAdapterCompatibleWallet;
 }
-
-/** TODO: docs */
-export type StandardAdapter = WalletAdapter & {
-    wallet: WalletAdapterCompatibleWallet;
-    standard: true;
-};
 
 /** TODO: docs */
 export class StandardWalletAdapter extends BaseWalletAdapter implements StandardAdapter {

--- a/packages/wallet-adapter/base/src/adapter.ts
+++ b/packages/wallet-adapter/base/src/adapter.ts
@@ -1,12 +1,12 @@
 import {
     BaseWalletAdapter,
     isVersionedTransaction,
-    isWalletAdapterCompatibleStandardWallet as isWalletAdapterCompatibleWallet,
+    isWalletAdapterCompatibleStandardWallet,
     type SendTransactionOptions,
-    type StandardWalletAdapter as StandardAdapter,
+    type StandardWalletAdapter as StandardWalletAdapterType,
     type SupportedTransactionVersions,
     WalletAccountError,
-    type WalletAdapterCompatibleStandardWallet as WalletAdapterCompatibleWallet,
+    type WalletAdapterCompatibleStandardWallet,
     WalletConfigError,
     WalletConnectionError,
     WalletDisconnectedError,
@@ -41,20 +41,39 @@ import {
 import { arraysEqual } from '@wallet-standard/wallet';
 import bs58 from 'bs58';
 
-export { StandardAdapter, WalletAdapterCompatibleWallet, isWalletAdapterCompatibleWallet };
+/**
+ * @deprecated Use `StandardWalletAdapter` from `@solana/wallet-adapter-base` instead.
+ *
+ * @group Deprecated
+ */
+export type StandardAdapter = StandardWalletAdapterType;
+
+/**
+ * @deprecated Use `WalletAdapterCompatibleStandardWallet` from `@solana/wallet-adapter-base` instead.
+ *
+ * @group Deprecated
+ */
+export type WalletAdapterCompatibleWallet = WalletAdapterCompatibleStandardWallet;
+
+/**
+ * @deprecated Use `isWalletAdapterCompatibleStandardWallet` from `@solana/wallet-adapter-base` instead.
+ *
+ * @group Deprecated
+ */
+export const isWalletAdapterCompatibleWallet = isWalletAdapterCompatibleStandardWallet;
 
 /** TODO: docs */
 export interface StandardWalletAdapterConfig {
-    wallet: WalletAdapterCompatibleWallet;
+    wallet: WalletAdapterCompatibleStandardWallet;
 }
 
 /** TODO: docs */
-export class StandardWalletAdapter extends BaseWalletAdapter implements StandardAdapter {
+export class StandardWalletAdapter extends BaseWalletAdapter implements StandardWalletAdapterType {
     #account: WalletAccount | null;
     #publicKey: PublicKey | null;
     #connecting: boolean;
     #off: (() => void) | undefined;
-    readonly #wallet: WalletAdapterCompatibleWallet;
+    readonly #wallet: WalletAdapterCompatibleStandardWallet;
     readonly #supportedTransactionVersions: SupportedTransactionVersions;
     readonly #readyState: WalletReadyState =
         typeof window === 'undefined' || typeof document === 'undefined'
@@ -89,7 +108,7 @@ export class StandardWalletAdapter extends BaseWalletAdapter implements Standard
         return this.#readyState;
     }
 
-    get wallet(): WalletAdapterCompatibleWallet {
+    get wallet(): WalletAdapterCompatibleStandardWallet {
         return this.#wallet;
     }
 

--- a/packages/wallet-adapter/base/src/adapter.ts
+++ b/packages/wallet-adapter/base/src/adapter.ts
@@ -71,7 +71,7 @@ export class StandardWalletAdapter extends BaseWalletAdapter implements Standard
     }
 
     get url() {
-        return 'https://github.com/wallet-standard';
+        return 'https://github.com/solana-labs/wallet-standard';
     }
 
     get publicKey() {

--- a/packages/wallet-adapter/base/src/adapter.ts
+++ b/packages/wallet-adapter/base/src/adapter.ts
@@ -1,7 +1,6 @@
 import {
     BaseWalletAdapter,
     isVersionedTransaction,
-    isWalletAdapterCompatibleStandardWallet,
     type SendTransactionOptions,
     type StandardWalletAdapter as StandardWalletAdapterType,
     type SupportedTransactionVersions,
@@ -40,27 +39,6 @@ import {
 } from '@wallet-standard/features';
 import { arraysEqual } from '@wallet-standard/wallet';
 import bs58 from 'bs58';
-
-/**
- * @deprecated Use `StandardWalletAdapter` from `@solana/wallet-adapter-base` instead.
- *
- * @group Deprecated
- */
-export type StandardAdapter = StandardWalletAdapterType;
-
-/**
- * @deprecated Use `WalletAdapterCompatibleStandardWallet` from `@solana/wallet-adapter-base` instead.
- *
- * @group Deprecated
- */
-export type WalletAdapterCompatibleWallet = WalletAdapterCompatibleStandardWallet;
-
-/**
- * @deprecated Use `isWalletAdapterCompatibleStandardWallet` from `@solana/wallet-adapter-base` instead.
- *
- * @group Deprecated
- */
-export const isWalletAdapterCompatibleWallet = isWalletAdapterCompatibleStandardWallet;
 
 /** TODO: docs */
 export interface StandardWalletAdapterConfig {

--- a/packages/wallet-adapter/base/src/index.ts
+++ b/packages/wallet-adapter/base/src/index.ts
@@ -1,2 +1,3 @@
 export * from './adapter.js';
+export * from './types.js';
 export * from './wallet.js';

--- a/packages/wallet-adapter/base/src/transaction.ts
+++ b/packages/wallet-adapter/base/src/transaction.ts
@@ -1,8 +1,0 @@
-import type { Transaction, VersionedTransaction } from '@solana/web3.js';
-
-/** @internal */
-export function isVersionedTransaction(
-    transaction: Transaction | VersionedTransaction
-): transaction is VersionedTransaction {
-    return 'version' in transaction;
-}

--- a/packages/wallet-adapter/base/src/types.ts
+++ b/packages/wallet-adapter/base/src/types.ts
@@ -1,0 +1,26 @@
+import {
+    isWalletAdapterCompatibleStandardWallet,
+    type StandardWalletAdapter,
+    type WalletAdapterCompatibleStandardWallet,
+} from '@solana/wallet-adapter-base';
+
+/**
+ * @deprecated Use `StandardWalletAdapter` from `@solana/wallet-adapter-base` instead.
+ *
+ * @group Deprecated
+ */
+export type StandardAdapter = StandardWalletAdapter;
+
+/**
+ * @deprecated Use `WalletAdapterCompatibleStandardWallet` from `@solana/wallet-adapter-base` instead.
+ *
+ * @group Deprecated
+ */
+export type WalletAdapterCompatibleWallet = WalletAdapterCompatibleStandardWallet;
+
+/**
+ * @deprecated Use `isWalletAdapterCompatibleStandardWallet` from `@solana/wallet-adapter-base` instead.
+ *
+ * @group Deprecated
+ */
+export const isWalletAdapterCompatibleWallet = isWalletAdapterCompatibleStandardWallet;

--- a/packages/wallet-adapter/base/src/wallet.ts
+++ b/packages/wallet-adapter/base/src/wallet.ts
@@ -1,15 +1,15 @@
-import { isVersionedTransaction, WalletReadyState, type Adapter } from '@solana/wallet-adapter-base';
+import { type Adapter, isVersionedTransaction, WalletReadyState } from '@solana/wallet-adapter-base';
 import { isSolanaChain, type SolanaChain } from '@solana/wallet-standard-chains';
 import {
     SolanaSignAndSendTransaction,
-    SolanaSignMessage,
-    SolanaSignTransaction,
     type SolanaSignAndSendTransactionFeature,
     type SolanaSignAndSendTransactionMethod,
     type SolanaSignAndSendTransactionOutput,
+    SolanaSignMessage,
     type SolanaSignMessageFeature,
     type SolanaSignMessageMethod,
     type SolanaSignMessageOutput,
+    SolanaSignTransaction,
     type SolanaSignTransactionFeature,
     type SolanaSignTransactionMethod,
     type SolanaSignTransactionOutput,
@@ -19,15 +19,18 @@ import { getEndpointForChain } from '@solana/wallet-standard-util';
 import { Connection, Transaction, VersionedTransaction } from '@solana/web3.js';
 import { getWallets } from '@wallet-standard/app';
 import type { Wallet, WalletIcon } from '@wallet-standard/base';
-import type {
-    ConnectFeature,
-    ConnectMethod,
-    DisconnectFeature,
-    DisconnectMethod,
-    EventsFeature,
-    EventsListeners,
-    EventsNames,
-    EventsOnMethod,
+import {
+    StandardConnect,
+    type StandardConnectFeature,
+    type StandardConnectMethod,
+    StandardDisconnect,
+    type StandardDisconnectFeature,
+    type StandardDisconnectMethod,
+    StandardEvents,
+    type StandardEventsFeature,
+    type StandardEventsListeners,
+    type StandardEventsNames,
+    type StandardEventsOnMethod,
 } from '@wallet-standard/features';
 import { arraysEqual, bytesEqual, ReadonlyWalletAccount } from '@wallet-standard/wallet';
 import bs58 from 'bs58';
@@ -45,7 +48,7 @@ export class SolanaWalletAdapterWalletAccount extends ReadonlyWalletAccount {
         adapter: Adapter;
         address: string;
         publicKey: Uint8Array;
-        chains: ReadonlyArray<SolanaChain>;
+        chains: readonly SolanaChain[];
     }) {
         const features: (keyof (SolanaSignAndSendTransactionFeature &
             SolanaSignTransactionFeature &
@@ -69,10 +72,10 @@ export class SolanaWalletAdapterWalletAccount extends ReadonlyWalletAccount {
 /** TODO: docs */
 export class SolanaWalletAdapterWallet implements Wallet {
     readonly #listeners: {
-        [E in EventsNames]?: EventsListeners[E][];
+        [E in StandardEventsNames]?: StandardEventsListeners[E][];
     } = {};
     readonly #adapter: Adapter;
-    readonly #supportedTransactionVersions: ReadonlyArray<SolanaTransactionVersion>;
+    readonly #supportedTransactionVersions: readonly SolanaTransactionVersion[];
     readonly #chain: SolanaChain;
     readonly #endpoint: string | undefined;
     #account: SolanaWalletAdapterWalletAccount | undefined;
@@ -93,20 +96,23 @@ export class SolanaWalletAdapterWallet implements Wallet {
         return [this.#chain];
     }
 
-    get features(): ConnectFeature &
-        DisconnectFeature &
+    get features(): StandardConnectFeature &
+        StandardDisconnectFeature &
         SolanaSignAndSendTransactionFeature &
         Partial<SolanaSignTransactionFeature & SolanaSignMessageFeature> {
-        const features: ConnectFeature & DisconnectFeature & EventsFeature & SolanaSignAndSendTransactionFeature = {
-            'standard:connect': {
+        const features: StandardConnectFeature &
+            StandardDisconnectFeature &
+            StandardEventsFeature &
+            SolanaSignAndSendTransactionFeature = {
+            [StandardConnect]: {
                 version: '1.0.0',
                 connect: this.#connect,
             },
-            'standard:disconnect': {
+            [StandardDisconnect]: {
                 version: '1.0.0',
                 disconnect: this.#disconnect,
             },
-            'standard:events': {
+            [StandardEvents]: {
                 version: '1.0.0',
                 on: this.#on,
             },
@@ -205,7 +211,7 @@ export class SolanaWalletAdapterWallet implements Wallet {
         }
     }
 
-    #connect: ConnectMethod = async ({ silent } = {}) => {
+    #connect: StandardConnectMethod = async ({ silent } = {}) => {
         if (!silent && !this.#adapter.connected) {
             await this.#adapter.connect();
         }
@@ -215,21 +221,21 @@ export class SolanaWalletAdapterWallet implements Wallet {
         return { accounts: this.accounts };
     };
 
-    #disconnect: DisconnectMethod = async () => {
+    #disconnect: StandardDisconnectMethod = async () => {
         await this.#adapter.disconnect();
     };
 
-    #on: EventsOnMethod = (event, listener) => {
+    #on: StandardEventsOnMethod = (event, listener) => {
         this.#listeners[event]?.push(listener) || (this.#listeners[event] = [listener]);
         return (): void => this.#off(event, listener);
     };
 
-    #emit<E extends EventsNames>(event: E, ...args: Parameters<EventsListeners[E]>): void {
+    #emit<E extends StandardEventsNames>(event: E, ...args: Parameters<StandardEventsListeners[E]>): void {
         // eslint-disable-next-line prefer-spread
         this.#listeners[event]?.forEach((listener) => listener.apply(null, args));
     }
 
-    #off<E extends EventsNames>(event: E, listener: EventsListeners[E]): void {
+    #off<E extends StandardEventsNames>(event: E, listener: StandardEventsListeners[E]): void {
         this.#listeners[event] = this.#listeners[event]?.filter((existingListener) => listener !== existingListener);
     }
 

--- a/packages/wallet-adapter/base/src/wallet.ts
+++ b/packages/wallet-adapter/base/src/wallet.ts
@@ -1,18 +1,19 @@
-import type { Adapter } from '@solana/wallet-adapter-base';
-import { WalletReadyState } from '@solana/wallet-adapter-base';
-import type { SolanaChain } from '@solana/wallet-standard-chains';
-import { isSolanaChain } from '@solana/wallet-standard-chains';
-import type {
-    SolanaSignAndSendTransactionFeature,
-    SolanaSignAndSendTransactionMethod,
-    SolanaSignAndSendTransactionOutput,
-    SolanaSignMessageFeature,
-    SolanaSignMessageMethod,
-    SolanaSignMessageOutput,
-    SolanaSignTransactionFeature,
-    SolanaSignTransactionMethod,
-    SolanaSignTransactionOutput,
-    SolanaTransactionVersion,
+import { isVersionedTransaction, WalletReadyState, type Adapter } from '@solana/wallet-adapter-base';
+import { isSolanaChain, type SolanaChain } from '@solana/wallet-standard-chains';
+import {
+    SolanaSignAndSendTransaction,
+    SolanaSignMessage,
+    SolanaSignTransaction,
+    type SolanaSignAndSendTransactionFeature,
+    type SolanaSignAndSendTransactionMethod,
+    type SolanaSignAndSendTransactionOutput,
+    type SolanaSignMessageFeature,
+    type SolanaSignMessageMethod,
+    type SolanaSignMessageOutput,
+    type SolanaSignTransactionFeature,
+    type SolanaSignTransactionMethod,
+    type SolanaSignTransactionOutput,
+    type SolanaTransactionVersion,
 } from '@solana/wallet-standard-features';
 import { getEndpointForChain } from '@solana/wallet-standard-util';
 import { Connection, Transaction, VersionedTransaction } from '@solana/web3.js';
@@ -30,7 +31,6 @@ import type {
 } from '@wallet-standard/features';
 import { arraysEqual, bytesEqual, ReadonlyWalletAccount } from '@wallet-standard/wallet';
 import bs58 from 'bs58';
-import { isVersionedTransaction } from './transaction.js';
 
 /** TODO: docs */
 export class SolanaWalletAdapterWalletAccount extends ReadonlyWalletAccount {
@@ -49,12 +49,12 @@ export class SolanaWalletAdapterWalletAccount extends ReadonlyWalletAccount {
     }) {
         const features: (keyof (SolanaSignAndSendTransactionFeature &
             SolanaSignTransactionFeature &
-            SolanaSignMessageFeature))[] = ['solana:signAndSendTransaction'];
+            SolanaSignMessageFeature))[] = [SolanaSignAndSendTransaction];
         if ('signTransaction' in adapter) {
-            features.push('solana:signTransaction');
+            features.push(SolanaSignTransaction);
         }
         if ('signMessage' in adapter) {
-            features.push('solana:signMessage');
+            features.push(SolanaSignMessage);
         }
 
         super({ address, publicKey, chains, features });
@@ -110,7 +110,7 @@ export class SolanaWalletAdapterWallet implements Wallet {
                 version: '1.0.0',
                 on: this.#on,
             },
-            'solana:signAndSendTransaction': {
+            [SolanaSignAndSendTransaction]: {
                 version: '1.0.0',
                 supportedTransactionVersions: this.#supportedTransactionVersions,
                 signAndSendTransaction: this.#signAndSendTransaction,
@@ -120,7 +120,7 @@ export class SolanaWalletAdapterWallet implements Wallet {
         let signTransactionFeature: SolanaSignTransactionFeature | undefined;
         if ('signTransaction' in this.#adapter) {
             signTransactionFeature = {
-                'solana:signTransaction': {
+                [SolanaSignTransaction]: {
                     version: '1.0.0',
                     supportedTransactionVersions: this.#supportedTransactionVersions,
                     signTransaction: this.#signTransaction,
@@ -131,7 +131,7 @@ export class SolanaWalletAdapterWallet implements Wallet {
         let signMessageFeature: SolanaSignMessageFeature | undefined;
         if ('signMessage' in this.#adapter) {
             signMessageFeature = {
-                'solana:signMessage': {
+                [SolanaSignMessage]: {
                     version: '1.0.0',
                     signMessage: this.#signMessage,
                 },

--- a/packages/wallet-adapter/react/package.json
+++ b/packages/wallet-adapter/react/package.json
@@ -35,8 +35,8 @@
     },
     "dependencies": {
         "@solana/wallet-standard-wallet-adapter-base": "workspace:^",
-        "@wallet-standard/app": "^1.0.0",
-        "@wallet-standard/base": "^1.0.0"
+        "@wallet-standard/app": "^1.0.1",
+        "@wallet-standard/base": "^1.0.1"
     },
     "devDependencies": {
         "@solana/wallet-adapter-base": "^0.9.21",

--- a/packages/wallet-adapter/react/package.json
+++ b/packages/wallet-adapter/react/package.json
@@ -39,7 +39,7 @@
         "@wallet-standard/base": "^1.0.0"
     },
     "devDependencies": {
-        "@solana/wallet-adapter-base": "^0.9.18",
+        "@solana/wallet-adapter-base": "^0.9.21",
         "@types/react": "^18.0.23",
         "react": "^18.2.0",
         "shx": "^0.3.4"

--- a/packages/wallet-adapter/react/src/useStandardWalletAdapters.ts
+++ b/packages/wallet-adapter/react/src/useStandardWalletAdapters.ts
@@ -53,6 +53,6 @@ function useConstant<T>(fn: () => T): T {
     return ref.current.value;
 }
 
-function wrapWalletsWithAdapters(wallets: ReadonlyArray<Wallet>): ReadonlyArray<StandardWalletAdapter> {
+function wrapWalletsWithAdapters(wallets: readonly Wallet[]): readonly StandardWalletAdapter[] {
     return wallets.filter(isWalletAdapterCompatibleWallet).map((wallet) => new StandardWalletAdapter({ wallet }));
 }

--- a/packages/wallets/ghost/package.json
+++ b/packages/wallets/ghost/package.json
@@ -25,7 +25,7 @@
         "build": "npm run clean && npm run tsc && npm run package"
     },
     "dependencies": {
-        "@solana/wallet-standard-features": "^1.0.0",
+        "@solana/wallet-standard-features": "^1.0.1",
         "@solana/web3.js": "^1.58.0",
         "@wallet-standard/base": "^1.0.1",
         "@wallet-standard/features": "^1.0.3",

--- a/packages/wallets/ghost/package.json
+++ b/packages/wallets/ghost/package.json
@@ -27,8 +27,8 @@
     "dependencies": {
         "@solana/wallet-standard-features": "^1.0.0",
         "@solana/web3.js": "^1.58.0",
-        "@wallet-standard/base": "^1.0.0",
-        "@wallet-standard/features": "^1.0.0",
+        "@wallet-standard/base": "^1.0.1",
+        "@wallet-standard/features": "^1.0.3",
         "bs58": "^4.0.1"
     },
     "devDependencies": {

--- a/packages/wallets/ghost/src/account.ts
+++ b/packages/wallets/ghost/src/account.ts
@@ -1,10 +1,15 @@
 // This is copied with modification from @wallet-standard/wallet
 
+import {
+    SolanaSignAndSendTransaction,
+    SolanaSignMessage,
+    SolanaSignTransaction,
+} from '@solana/wallet-standard-features';
 import type { WalletAccount } from '@wallet-standard/base';
 import { SOLANA_CHAINS } from './solana.js';
 
 const chains = SOLANA_CHAINS;
-const features = ['solana:signAndSendTransaction', 'solana:signMessage', 'solana:signTransaction'] as const;
+const features = [SolanaSignAndSendTransaction, SolanaSignTransaction, SolanaSignMessage] as const;
 
 export class GhostWalletAccount implements WalletAccount {
     readonly #address: WalletAccount['address'];

--- a/packages/wallets/ghost/src/solana.ts
+++ b/packages/wallets/ghost/src/solana.ts
@@ -23,7 +23,7 @@ export const SOLANA_CHAINS = [
 ] as const;
 
 /** Type of all Solana clusters */
-export type SolanaChain = typeof SOLANA_CHAINS[number];
+export type SolanaChain = (typeof SOLANA_CHAINS)[number];
 
 /**
  * Check if a chain corresponds with one of the Solana clusters.

--- a/packages/wallets/ghost/src/wallet.ts
+++ b/packages/wallets/ghost/src/wallet.ts
@@ -1,25 +1,31 @@
-import type {
-    SolanaSignAndSendTransactionFeature,
-    SolanaSignAndSendTransactionMethod,
-    SolanaSignAndSendTransactionOutput,
-    SolanaSignMessageFeature,
-    SolanaSignMessageMethod,
-    SolanaSignMessageOutput,
-    SolanaSignTransactionFeature,
-    SolanaSignTransactionMethod,
-    SolanaSignTransactionOutput,
+import {
+    SolanaSignAndSendTransaction,
+    SolanaSignMessage,
+    SolanaSignTransaction,
+    type SolanaSignAndSendTransactionFeature,
+    type SolanaSignAndSendTransactionMethod,
+    type SolanaSignAndSendTransactionOutput,
+    type SolanaSignMessageFeature,
+    type SolanaSignMessageMethod,
+    type SolanaSignMessageOutput,
+    type SolanaSignTransactionFeature,
+    type SolanaSignTransactionMethod,
+    type SolanaSignTransactionOutput,
 } from '@solana/wallet-standard-features';
 import { Transaction, VersionedTransaction } from '@solana/web3.js';
 import type { Wallet } from '@wallet-standard/base';
-import type {
-    ConnectFeature,
-    ConnectMethod,
-    DisconnectFeature,
-    DisconnectMethod,
-    EventsFeature,
-    EventsListeners,
-    EventsNames,
-    EventsOnMethod,
+import {
+    Connect,
+    Disconnect,
+    Events,
+    type ConnectFeature,
+    type ConnectMethod,
+    type DisconnectFeature,
+    type DisconnectMethod,
+    type EventsFeature,
+    type EventsListeners,
+    type EventsNames,
+    type EventsOnMethod,
 } from '@wallet-standard/features';
 import bs58 from 'bs58';
 import { GhostWalletAccount } from './account.js';
@@ -29,8 +35,10 @@ import { isSolanaChain, SOLANA_CHAINS } from './solana.js';
 import { bytesEqual } from './util.js';
 import type { Ghost } from './window.js';
 
+export const Ghost = 'ghost:';
+
 export type GhostFeature = {
-    'ghost:': {
+    [Ghost]: {
         ghost: Ghost;
     };
 };
@@ -67,33 +75,33 @@ export class GhostWallet implements Wallet {
         SolanaSignMessageFeature &
         GhostFeature {
         return {
-            'standard:connect': {
+            [Connect]: {
                 version: '1.0.0',
                 connect: this.#connect,
             },
-            'standard:disconnect': {
+            [Disconnect]: {
                 version: '1.0.0',
                 disconnect: this.#disconnect,
             },
-            'standard:events': {
+            [Events]: {
                 version: '1.0.0',
                 on: this.#on,
             },
-            'solana:signAndSendTransaction': {
+            [SolanaSignAndSendTransaction]: {
                 version: '1.0.0',
                 supportedTransactionVersions: ['legacy', 0],
                 signAndSendTransaction: this.#signAndSendTransaction,
             },
-            'solana:signTransaction': {
+            [SolanaSignTransaction]: {
                 version: '1.0.0',
                 supportedTransactionVersions: ['legacy', 0],
                 signTransaction: this.#signTransaction,
             },
-            'solana:signMessage': {
+            [SolanaSignMessage]: {
                 version: '1.0.0',
                 signMessage: this.#signMessage,
             },
-            'ghost:': {
+            [Ghost]: {
                 ghost: this.#ghost,
             },
         };

--- a/packages/wallets/ghost/src/wallet.ts
+++ b/packages/wallets/ghost/src/wallet.ts
@@ -1,13 +1,13 @@
 import {
     SolanaSignAndSendTransaction,
-    SolanaSignMessage,
-    SolanaSignTransaction,
     type SolanaSignAndSendTransactionFeature,
     type SolanaSignAndSendTransactionMethod,
     type SolanaSignAndSendTransactionOutput,
+    SolanaSignMessage,
     type SolanaSignMessageFeature,
     type SolanaSignMessageMethod,
     type SolanaSignMessageOutput,
+    SolanaSignTransaction,
     type SolanaSignTransactionFeature,
     type SolanaSignTransactionMethod,
     type SolanaSignTransactionOutput,
@@ -15,17 +15,17 @@ import {
 import { Transaction, VersionedTransaction } from '@solana/web3.js';
 import type { Wallet } from '@wallet-standard/base';
 import {
-    Connect,
-    Disconnect,
-    Events,
-    type ConnectFeature,
-    type ConnectMethod,
-    type DisconnectFeature,
-    type DisconnectMethod,
-    type EventsFeature,
-    type EventsListeners,
-    type EventsNames,
-    type EventsOnMethod,
+    StandardConnect,
+    type StandardConnectFeature,
+    type StandardConnectMethod,
+    StandardDisconnect,
+    type StandardDisconnectFeature,
+    type StandardDisconnectMethod,
+    StandardEvents,
+    type StandardEventsFeature,
+    type StandardEventsListeners,
+    type StandardEventsNames,
+    type StandardEventsOnMethod,
 } from '@wallet-standard/features';
 import bs58 from 'bs58';
 import { GhostWalletAccount } from './account.js';
@@ -35,16 +35,16 @@ import { isSolanaChain, SOLANA_CHAINS } from './solana.js';
 import { bytesEqual } from './util.js';
 import type { Ghost } from './window.js';
 
-export const Ghost = 'ghost:';
+export const GhostNamespace = 'ghost:';
 
 export type GhostFeature = {
-    [Ghost]: {
+    [GhostNamespace]: {
         ghost: Ghost;
     };
 };
 
 export class GhostWallet implements Wallet {
-    readonly #listeners: { [E in EventsNames]?: EventsListeners[E][] } = {};
+    readonly #listeners: { [E in StandardEventsNames]?: StandardEventsListeners[E][] } = {};
     readonly #version = '1.0.0' as const;
     readonly #name = 'Ghost' as const;
     readonly #icon = icon;
@@ -67,23 +67,23 @@ export class GhostWallet implements Wallet {
         return SOLANA_CHAINS.slice();
     }
 
-    get features(): ConnectFeature &
-        DisconnectFeature &
-        EventsFeature &
+    get features(): StandardConnectFeature &
+        StandardDisconnectFeature &
+        StandardEventsFeature &
         SolanaSignAndSendTransactionFeature &
         SolanaSignTransactionFeature &
         SolanaSignMessageFeature &
         GhostFeature {
         return {
-            [Connect]: {
+            [StandardConnect]: {
                 version: '1.0.0',
                 connect: this.#connect,
             },
-            [Disconnect]: {
+            [StandardDisconnect]: {
                 version: '1.0.0',
                 disconnect: this.#disconnect,
             },
-            [Events]: {
+            [StandardEvents]: {
                 version: '1.0.0',
                 on: this.#on,
             },
@@ -101,7 +101,7 @@ export class GhostWallet implements Wallet {
                 version: '1.0.0',
                 signMessage: this.#signMessage,
             },
-            [Ghost]: {
+            [GhostNamespace]: {
                 ghost: this.#ghost,
             },
         };
@@ -125,17 +125,17 @@ export class GhostWallet implements Wallet {
         this.#connected();
     }
 
-    #on: EventsOnMethod = (event, listener) => {
+    #on: StandardEventsOnMethod = (event, listener) => {
         this.#listeners[event]?.push(listener) || (this.#listeners[event] = [listener]);
         return (): void => this.#off(event, listener);
     };
 
-    #emit<E extends EventsNames>(event: E, ...args: Parameters<EventsListeners[E]>): void {
+    #emit<E extends StandardEventsNames>(event: E, ...args: Parameters<StandardEventsListeners[E]>): void {
         // eslint-disable-next-line prefer-spread
         this.#listeners[event]?.forEach((listener) => listener.apply(null, args));
     }
 
-    #off<E extends EventsNames>(event: E, listener: EventsListeners[E]): void {
+    #off<E extends StandardEventsNames>(event: E, listener: StandardEventsListeners[E]): void {
         this.#listeners[event] = this.#listeners[event]?.filter((existingListener) => listener !== existingListener);
     }
 
@@ -168,7 +168,7 @@ export class GhostWallet implements Wallet {
         }
     };
 
-    #connect: ConnectMethod = async ({ silent } = {}) => {
+    #connect: StandardConnectMethod = async ({ silent } = {}) => {
         if (!this.#account) {
             await this.#ghost.connect(silent ? { onlyIfTrusted: true } : undefined);
         }
@@ -178,7 +178,7 @@ export class GhostWallet implements Wallet {
         return { accounts: this.accounts };
     };
 
-    #disconnect: DisconnectMethod = async () => {
+    #disconnect: StandardDisconnectMethod = async () => {
         await this.#ghost.disconnect();
     };
 

--- a/packages/wallets/phantom/package.json
+++ b/packages/wallets/phantom/package.json
@@ -25,7 +25,7 @@
         "build": "npm run clean && npm run tsc && npm run package"
     },
     "dependencies": {
-        "@solana/wallet-standard-features": "^1.0.0",
+        "@solana/wallet-standard-features": "^1.0.1",
         "@solana/web3.js": "^1.58.0",
         "@wallet-standard/base": "^1.0.1",
         "@wallet-standard/features": "^1.0.3",

--- a/packages/wallets/phantom/package.json
+++ b/packages/wallets/phantom/package.json
@@ -27,8 +27,8 @@
     "dependencies": {
         "@solana/wallet-standard-features": "^1.0.0",
         "@solana/web3.js": "^1.58.0",
-        "@wallet-standard/base": "^1.0.0",
-        "@wallet-standard/features": "^1.0.0",
+        "@wallet-standard/base": "^1.0.1",
+        "@wallet-standard/features": "^1.0.3",
         "bs58": "^4.0.1"
     },
     "devDependencies": {

--- a/packages/wallets/phantom/src/account.ts
+++ b/packages/wallets/phantom/src/account.ts
@@ -1,10 +1,15 @@
 // This is copied with modification from @wallet-standard/wallet
 
+import {
+    SolanaSignAndSendTransaction,
+    SolanaSignMessage,
+    SolanaSignTransaction,
+} from '@solana/wallet-standard-features';
 import type { WalletAccount } from '@wallet-standard/base';
 import { SOLANA_CHAINS } from './solana.js';
 
 const chains = SOLANA_CHAINS;
-const features = ['solana:signAndSendTransaction', 'solana:signMessage', 'solana:signTransaction'] as const;
+const features = [SolanaSignAndSendTransaction, SolanaSignTransaction, SolanaSignMessage] as const;
 
 export class PhantomWalletAccount implements WalletAccount {
     readonly #address: WalletAccount['address'];

--- a/packages/wallets/phantom/src/solana.ts
+++ b/packages/wallets/phantom/src/solana.ts
@@ -23,7 +23,7 @@ export const SOLANA_CHAINS = [
 ] as const;
 
 /** Type of all Solana clusters */
-export type SolanaChain = typeof SOLANA_CHAINS[number];
+export type SolanaChain = (typeof SOLANA_CHAINS)[number];
 
 /**
  * Check if a chain corresponds with one of the Solana clusters.

--- a/packages/wallets/phantom/src/wallet.ts
+++ b/packages/wallets/phantom/src/wallet.ts
@@ -1,13 +1,13 @@
 import {
     SolanaSignAndSendTransaction,
-    SolanaSignMessage,
-    SolanaSignTransaction,
     type SolanaSignAndSendTransactionFeature,
     type SolanaSignAndSendTransactionMethod,
     type SolanaSignAndSendTransactionOutput,
+    SolanaSignMessage,
     type SolanaSignMessageFeature,
     type SolanaSignMessageMethod,
     type SolanaSignMessageOutput,
+    SolanaSignTransaction,
     type SolanaSignTransactionFeature,
     type SolanaSignTransactionMethod,
     type SolanaSignTransactionOutput,
@@ -15,17 +15,17 @@ import {
 import { Transaction } from '@solana/web3.js';
 import type { Wallet } from '@wallet-standard/base';
 import {
-    Connect,
-    Disconnect,
-    Events,
-    type ConnectFeature,
-    type ConnectMethod,
-    type DisconnectFeature,
-    type DisconnectMethod,
-    type EventsFeature,
-    type EventsListeners,
-    type EventsNames,
-    type EventsOnMethod,
+    StandardConnect,
+    type StandardConnectFeature,
+    type StandardConnectMethod,
+    StandardDisconnect,
+    type StandardDisconnectFeature,
+    type StandardDisconnectMethod,
+    StandardEvents,
+    type StandardEventsFeature,
+    type StandardEventsListeners,
+    type StandardEventsNames,
+    type StandardEventsOnMethod,
 } from '@wallet-standard/features';
 import bs58 from 'bs58';
 import { PhantomWalletAccount } from './account.js';
@@ -35,16 +35,16 @@ import { isSolanaChain, SOLANA_CHAINS } from './solana.js';
 import { bytesEqual } from './util.js';
 import type { WindowPhantom } from './window.js';
 
-export const Phantom = 'phantom:';
+export const PhantomNamespace = 'phantom:';
 
 export type PhantomFeature = {
-    [Phantom]: {
+    [PhantomNamespace]: {
         phantom: WindowPhantom;
     };
 };
 
 export class PhantomWallet implements Wallet {
-    readonly #listeners: { [E in EventsNames]?: EventsListeners[E][] } = {};
+    readonly #listeners: { [E in StandardEventsNames]?: StandardEventsListeners[E][] } = {};
     readonly #version = '1.0.0' as const;
     readonly #name = 'Phantom' as const;
     readonly #icon = icon;
@@ -67,23 +67,23 @@ export class PhantomWallet implements Wallet {
         return SOLANA_CHAINS.slice();
     }
 
-    get features(): ConnectFeature &
-        DisconnectFeature &
-        EventsFeature &
+    get features(): StandardConnectFeature &
+        StandardDisconnectFeature &
+        StandardEventsFeature &
         SolanaSignAndSendTransactionFeature &
         SolanaSignTransactionFeature &
         SolanaSignMessageFeature &
         PhantomFeature {
         return {
-            [Connect]: {
+            [StandardConnect]: {
                 version: '1.0.0',
                 connect: this.#connect,
             },
-            [Disconnect]: {
+            [StandardDisconnect]: {
                 version: '1.0.0',
                 disconnect: this.#disconnect,
             },
-            [Events]: {
+            [StandardEvents]: {
                 version: '1.0.0',
                 on: this.#on,
             },
@@ -101,7 +101,7 @@ export class PhantomWallet implements Wallet {
                 version: '1.0.0',
                 signMessage: this.#signMessage,
             },
-            [Phantom]: {
+            [PhantomNamespace]: {
                 phantom: this.#phantom,
             },
         };
@@ -125,17 +125,17 @@ export class PhantomWallet implements Wallet {
         this.#connected();
     }
 
-    #on: EventsOnMethod = (event, listener) => {
+    #on: StandardEventsOnMethod = (event, listener) => {
         this.#listeners[event]?.push(listener) || (this.#listeners[event] = [listener]);
         return (): void => this.#off(event, listener);
     };
 
-    #emit<E extends EventsNames>(event: E, ...args: Parameters<EventsListeners[E]>): void {
+    #emit<E extends StandardEventsNames>(event: E, ...args: Parameters<StandardEventsListeners[E]>): void {
         // eslint-disable-next-line prefer-spread
         this.#listeners[event]?.forEach((listener) => listener.apply(null, args));
     }
 
-    #off<E extends EventsNames>(event: E, listener: EventsListeners[E]): void {
+    #off<E extends StandardEventsNames>(event: E, listener: StandardEventsListeners[E]): void {
         this.#listeners[event] = this.#listeners[event]?.filter((existingListener) => listener !== existingListener);
     }
 
@@ -168,7 +168,7 @@ export class PhantomWallet implements Wallet {
         }
     };
 
-    #connect: ConnectMethod = async ({ silent } = {}) => {
+    #connect: StandardConnectMethod = async ({ silent } = {}) => {
         if (!this.#account) {
             await this.#phantom.solana.connect(silent ? { onlyIfTrusted: true } : undefined);
         }
@@ -178,7 +178,7 @@ export class PhantomWallet implements Wallet {
         return { accounts: this.accounts };
     };
 
-    #disconnect: DisconnectMethod = async () => {
+    #disconnect: StandardDisconnectMethod = async () => {
         await this.#phantom.solana.disconnect();
     };
 

--- a/packages/wallets/phantom/src/wallet.ts
+++ b/packages/wallets/phantom/src/wallet.ts
@@ -1,25 +1,31 @@
-import type {
-    SolanaSignAndSendTransactionFeature,
-    SolanaSignAndSendTransactionMethod,
-    SolanaSignAndSendTransactionOutput,
-    SolanaSignMessageFeature,
-    SolanaSignMessageMethod,
-    SolanaSignMessageOutput,
-    SolanaSignTransactionFeature,
-    SolanaSignTransactionMethod,
-    SolanaSignTransactionOutput,
+import {
+    SolanaSignAndSendTransaction,
+    SolanaSignMessage,
+    SolanaSignTransaction,
+    type SolanaSignAndSendTransactionFeature,
+    type SolanaSignAndSendTransactionMethod,
+    type SolanaSignAndSendTransactionOutput,
+    type SolanaSignMessageFeature,
+    type SolanaSignMessageMethod,
+    type SolanaSignMessageOutput,
+    type SolanaSignTransactionFeature,
+    type SolanaSignTransactionMethod,
+    type SolanaSignTransactionOutput,
 } from '@solana/wallet-standard-features';
 import { Transaction } from '@solana/web3.js';
 import type { Wallet } from '@wallet-standard/base';
-import type {
-    ConnectFeature,
-    ConnectMethod,
-    DisconnectFeature,
-    DisconnectMethod,
-    EventsFeature,
-    EventsListeners,
-    EventsNames,
-    EventsOnMethod,
+import {
+    Connect,
+    Disconnect,
+    Events,
+    type ConnectFeature,
+    type ConnectMethod,
+    type DisconnectFeature,
+    type DisconnectMethod,
+    type EventsFeature,
+    type EventsListeners,
+    type EventsNames,
+    type EventsOnMethod,
 } from '@wallet-standard/features';
 import bs58 from 'bs58';
 import { PhantomWalletAccount } from './account.js';
@@ -29,8 +35,10 @@ import { isSolanaChain, SOLANA_CHAINS } from './solana.js';
 import { bytesEqual } from './util.js';
 import type { WindowPhantom } from './window.js';
 
+export const Phantom = 'phantom:';
+
 export type PhantomFeature = {
-    'phantom:': {
+    [Phantom]: {
         phantom: WindowPhantom;
     };
 };
@@ -67,33 +75,33 @@ export class PhantomWallet implements Wallet {
         SolanaSignMessageFeature &
         PhantomFeature {
         return {
-            'standard:connect': {
+            [Connect]: {
                 version: '1.0.0',
                 connect: this.#connect,
             },
-            'standard:disconnect': {
+            [Disconnect]: {
                 version: '1.0.0',
                 disconnect: this.#disconnect,
             },
-            'standard:events': {
+            [Events]: {
                 version: '1.0.0',
                 on: this.#on,
             },
-            'solana:signAndSendTransaction': {
+            [SolanaSignAndSendTransaction]: {
                 version: '1.0.0',
                 supportedTransactionVersions: ['legacy'],
                 signAndSendTransaction: this.#signAndSendTransaction,
             },
-            'solana:signTransaction': {
+            [SolanaSignTransaction]: {
                 version: '1.0.0',
                 supportedTransactionVersions: ['legacy'],
                 signTransaction: this.#signTransaction,
             },
-            'solana:signMessage': {
+            [SolanaSignMessage]: {
                 version: '1.0.0',
                 signMessage: this.#signMessage,
             },
-            'phantom:': {
+            [Phantom]: {
                 phantom: this.#phantom,
             },
         };

--- a/packages/wallets/solflare/package.json
+++ b/packages/wallets/solflare/package.json
@@ -25,7 +25,7 @@
         "build": "npm run clean && npm run tsc && npm run package"
     },
     "dependencies": {
-        "@solana/wallet-standard-features": "^1.0.0",
+        "@solana/wallet-standard-features": "^1.0.1",
         "@solana/web3.js": "^1.58.0",
         "@solflare-wallet/sdk": "^1.1.0",
         "@wallet-standard/base": "^1.0.1",

--- a/packages/wallets/solflare/package.json
+++ b/packages/wallets/solflare/package.json
@@ -28,8 +28,8 @@
         "@solana/wallet-standard-features": "^1.0.0",
         "@solana/web3.js": "^1.58.0",
         "@solflare-wallet/sdk": "^1.1.0",
-        "@wallet-standard/base": "^1.0.0",
-        "@wallet-standard/features": "^1.0.0",
+        "@wallet-standard/base": "^1.0.1",
+        "@wallet-standard/features": "^1.0.3",
         "bs58": "^4.0.1"
     },
     "devDependencies": {

--- a/packages/wallets/solflare/src/account.ts
+++ b/packages/wallets/solflare/src/account.ts
@@ -1,10 +1,15 @@
 // This is copied with modification from @wallet-standard/wallet
 
+import {
+    SolanaSignAndSendTransaction,
+    SolanaSignMessage,
+    SolanaSignTransaction,
+} from '@solana/wallet-standard-features';
 import type { WalletAccount } from '@wallet-standard/base';
 import { SOLANA_CHAINS } from './solana.js';
 
 const chains = SOLANA_CHAINS;
-const features = ['solana:signAndSendTransaction', 'solana:signMessage', 'solana:signTransaction'] as const;
+const features = [SolanaSignAndSendTransaction, SolanaSignTransaction, SolanaSignMessage] as const;
 
 export class SolflareWalletAccount implements WalletAccount {
     readonly #address: WalletAccount['address'];

--- a/packages/wallets/solflare/src/solana.ts
+++ b/packages/wallets/solflare/src/solana.ts
@@ -23,7 +23,7 @@ export const SOLANA_CHAINS = [
 ] as const;
 
 /** Type of all Solana clusters */
-export type SolanaChain = typeof SOLANA_CHAINS[number];
+export type SolanaChain = (typeof SOLANA_CHAINS)[number];
 
 /**
  * Check if a chain corresponds with one of the Solana clusters.

--- a/packages/wallets/solflare/src/wallet.ts
+++ b/packages/wallets/solflare/src/wallet.ts
@@ -1,26 +1,32 @@
-import type {
-    SolanaSignAndSendTransactionFeature,
-    SolanaSignAndSendTransactionMethod,
-    SolanaSignAndSendTransactionOutput,
-    SolanaSignMessageFeature,
-    SolanaSignMessageMethod,
-    SolanaSignMessageOutput,
-    SolanaSignTransactionFeature,
-    SolanaSignTransactionMethod,
-    SolanaSignTransactionOutput,
+import {
+    SolanaSignAndSendTransaction,
+    SolanaSignMessage,
+    SolanaSignTransaction,
+    type SolanaSignAndSendTransactionFeature,
+    type SolanaSignAndSendTransactionMethod,
+    type SolanaSignAndSendTransactionOutput,
+    type SolanaSignMessageFeature,
+    type SolanaSignMessageMethod,
+    type SolanaSignMessageOutput,
+    type SolanaSignTransactionFeature,
+    type SolanaSignTransactionMethod,
+    type SolanaSignTransactionOutput,
 } from '@solana/wallet-standard-features';
 import { Connection, VersionedTransaction } from '@solana/web3.js';
 import Solflare from '@solflare-wallet/sdk';
 import type { Wallet } from '@wallet-standard/base';
-import type {
-    ConnectFeature,
-    ConnectMethod,
-    DisconnectFeature,
-    DisconnectMethod,
-    EventsFeature,
-    EventsListeners,
-    EventsNames,
-    EventsOnMethod,
+import {
+    Connect,
+    Disconnect,
+    Events,
+    type ConnectFeature,
+    type ConnectMethod,
+    type DisconnectFeature,
+    type DisconnectMethod,
+    type EventsFeature,
+    type EventsListeners,
+    type EventsNames,
+    type EventsOnMethod,
 } from '@wallet-standard/features';
 import bs58 from 'bs58';
 import { SolflareWalletAccount } from './account.js';
@@ -30,8 +36,10 @@ import type { SolanaChain } from './solana.js';
 import { isSolanaChain, SOLANA_CHAINS } from './solana.js';
 import { bytesEqual } from './util.js';
 
+export const SolflareName = 'solflare:';
+
 export type SolflareFeature = {
-    'solflare:': {
+    [SolflareName]: {
         solflare: Solflare;
     };
 };
@@ -68,33 +76,33 @@ export class SolflareWallet implements Wallet {
         SolanaSignMessageFeature &
         SolflareFeature {
         return {
-            'standard:connect': {
+            [Connect]: {
                 version: '1.0.0',
                 connect: this.#connect,
             },
-            'standard:disconnect': {
+            [Disconnect]: {
                 version: '1.0.0',
                 disconnect: this.#disconnect,
             },
-            'standard:events': {
+            [Events]: {
                 version: '1.0.0',
                 on: this.#on,
             },
-            'solana:signAndSendTransaction': {
+            [SolanaSignAndSendTransaction]: {
                 version: '1.0.0',
                 supportedTransactionVersions: ['legacy', 0],
                 signAndSendTransaction: this.#signAndSendTransaction,
             },
-            'solana:signTransaction': {
+            [SolanaSignTransaction]: {
                 version: '1.0.0',
                 supportedTransactionVersions: ['legacy', 0],
                 signTransaction: this.#signTransaction,
             },
-            'solana:signMessage': {
+            [SolanaSignMessage]: {
                 version: '1.0.0',
                 signMessage: this.#signMessage,
             },
-            'solflare:': { solflare: this.#solflare },
+            [SolflareName]: { solflare: this.#solflare },
         };
     }
 

--- a/packages/wallets/solflare/src/wallet.ts
+++ b/packages/wallets/solflare/src/wallet.ts
@@ -1,13 +1,13 @@
 import {
     SolanaSignAndSendTransaction,
-    SolanaSignMessage,
-    SolanaSignTransaction,
     type SolanaSignAndSendTransactionFeature,
     type SolanaSignAndSendTransactionMethod,
     type SolanaSignAndSendTransactionOutput,
+    SolanaSignMessage,
     type SolanaSignMessageFeature,
     type SolanaSignMessageMethod,
     type SolanaSignMessageOutput,
+    SolanaSignTransaction,
     type SolanaSignTransactionFeature,
     type SolanaSignTransactionMethod,
     type SolanaSignTransactionOutput,
@@ -16,17 +16,17 @@ import { Connection, VersionedTransaction } from '@solana/web3.js';
 import Solflare from '@solflare-wallet/sdk';
 import type { Wallet } from '@wallet-standard/base';
 import {
-    Connect,
-    Disconnect,
-    Events,
-    type ConnectFeature,
-    type ConnectMethod,
-    type DisconnectFeature,
-    type DisconnectMethod,
-    type EventsFeature,
-    type EventsListeners,
-    type EventsNames,
-    type EventsOnMethod,
+    StandardConnect,
+    type StandardConnectFeature,
+    type StandardConnectMethod,
+    StandardDisconnect,
+    type StandardDisconnectFeature,
+    type StandardDisconnectMethod,
+    StandardEvents,
+    type StandardEventsFeature,
+    type StandardEventsListeners,
+    type StandardEventsNames,
+    type StandardEventsOnMethod,
 } from '@wallet-standard/features';
 import bs58 from 'bs58';
 import { SolflareWalletAccount } from './account.js';
@@ -36,17 +36,17 @@ import type { SolanaChain } from './solana.js';
 import { isSolanaChain, SOLANA_CHAINS } from './solana.js';
 import { bytesEqual } from './util.js';
 
-export const SolflareName = 'solflare:';
+export const SolflareNamespace = 'solflare:';
 
 export type SolflareFeature = {
-    [SolflareName]: {
+    [SolflareNamespace]: {
         solflare: Solflare;
     };
 };
 
 export class SolflareWallet implements Wallet {
     readonly #solflare = new Solflare();
-    readonly #listeners: { [E in EventsNames]?: EventsListeners[E][] } = {};
+    readonly #listeners: { [E in StandardEventsNames]?: StandardEventsListeners[E][] } = {};
     readonly #version = '1.0.0' as const;
     readonly #name = 'Solflare' as const;
     readonly #icon = icon;
@@ -68,23 +68,23 @@ export class SolflareWallet implements Wallet {
         return SOLANA_CHAINS.slice();
     }
 
-    get features(): ConnectFeature &
-        DisconnectFeature &
-        EventsFeature &
+    get features(): StandardConnectFeature &
+        StandardDisconnectFeature &
+        StandardEventsFeature &
         SolanaSignAndSendTransactionFeature &
         SolanaSignTransactionFeature &
         SolanaSignMessageFeature &
         SolflareFeature {
         return {
-            [Connect]: {
+            [StandardConnect]: {
                 version: '1.0.0',
                 connect: this.#connect,
             },
-            [Disconnect]: {
+            [StandardDisconnect]: {
                 version: '1.0.0',
                 disconnect: this.#disconnect,
             },
-            [Events]: {
+            [StandardEvents]: {
                 version: '1.0.0',
                 on: this.#on,
             },
@@ -102,7 +102,7 @@ export class SolflareWallet implements Wallet {
                 version: '1.0.0',
                 signMessage: this.#signMessage,
             },
-            [SolflareName]: { solflare: this.#solflare },
+            [SolflareNamespace]: { solflare: this.#solflare },
         };
     }
 
@@ -122,17 +122,17 @@ export class SolflareWallet implements Wallet {
         this.#connected();
     }
 
-    #on: EventsOnMethod = (event, listener) => {
+    #on: StandardEventsOnMethod = (event, listener) => {
         this.#listeners[event]?.push(listener) || (this.#listeners[event] = [listener]);
         return (): void => this.#off(event, listener);
     };
 
-    #emit<E extends EventsNames>(event: E, ...args: Parameters<EventsListeners[E]>): void {
+    #emit<E extends StandardEventsNames>(event: E, ...args: Parameters<StandardEventsListeners[E]>): void {
         // eslint-disable-next-line prefer-spread
         this.#listeners[event]?.forEach((listener) => listener.apply(null, args));
     }
 
-    #off<E extends EventsNames>(event: E, listener: EventsListeners[E]): void {
+    #off<E extends StandardEventsNames>(event: E, listener: StandardEventsListeners[E]): void {
         this.#listeners[event] = this.#listeners[event]?.filter((existingListener) => listener !== existingListener);
     }
 
@@ -165,7 +165,7 @@ export class SolflareWallet implements Wallet {
         }
     };
 
-    #connect: ConnectMethod = async ({ silent } = {}) => {
+    #connect: StandardConnectMethod = async ({ silent } = {}) => {
         if (!silent && !this.#solflare.publicKey) {
             await this.#solflare.connect();
         }
@@ -175,7 +175,7 @@ export class SolflareWallet implements Wallet {
         return { accounts: this.accounts };
     };
 
-    #disconnect: DisconnectMethod = async () => {
+    #disconnect: StandardDisconnectMethod = async () => {
         await this.#solflare.disconnect();
     };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,22 +25,22 @@ importers:
       typedoc: ^0.23.18
       typescript: ~4.7.4
     devDependencies:
-      '@changesets/cli': 2.25.0
+      '@changesets/cli': 2.26.0
       '@types/chrome': 0.0.195
-      '@types/node': 18.11.7
-      '@typescript-eslint/eslint-plugin': 5.41.0_rydi7wwjgn4gtr73oslg4mokxa
-      '@typescript-eslint/parser': 5.41.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@types/node': 18.14.0
+      '@typescript-eslint/eslint-plugin': 5.52.0_44oiodj6oihskayaxpgdr6lwb4
+      '@typescript-eslint/parser': 5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq
       eslint: 8.22.0
-      eslint-config-prettier: 8.5.0_eslint@8.22.0
-      eslint-plugin-prettier: 4.2.1_i2cojdczqdiurzgttlwdgf764e
-      eslint-plugin-react: 7.31.10_eslint@8.22.0
+      eslint-config-prettier: 8.6.0_eslint@8.22.0
+      eslint-plugin-prettier: 4.2.1_qt54dw5ublwxu5wgrb6fweerp4
+      eslint-plugin-react: 7.32.2_eslint@8.22.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.22.0
-      eslint-plugin-require-extensions: 0.1.1_eslint@8.22.0
+      eslint-plugin-require-extensions: 0.1.2_eslint@8.22.0
       gh-pages: 4.0.0
-      pnpm: 7.14.0
-      prettier: 2.7.1
+      pnpm: 7.27.1
+      prettier: 2.8.4
       shx: 0.3.4
-      typedoc: 0.23.19_typescript@4.7.4
+      typedoc: 0.23.25_typescript@4.7.4
       typescript: 4.7.4
 
   packages/_/_:
@@ -72,7 +72,7 @@ importers:
       '@wallet-standard/base': ^1.0.0
       shx: ^0.3.4
     dependencies:
-      '@wallet-standard/base': 1.0.0
+      '@wallet-standard/base': 1.0.1
     devDependencies:
       shx: 0.3.4
 
@@ -82,8 +82,8 @@ importers:
       '@wallet-standard/features': ^1.0.0
       shx: ^0.3.4
     dependencies:
-      '@wallet-standard/base': 1.0.0
-      '@wallet-standard/features': 1.0.0
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.1
     devDependencies:
       shx: 0.3.4
 
@@ -111,7 +111,7 @@ importers:
 
   packages/wallet-adapter/base:
     specifiers:
-      '@solana/wallet-adapter-base': ^0.9.18
+      '@solana/wallet-adapter-base': ^0.9.21
       '@solana/wallet-standard-chains': workspace:^
       '@solana/wallet-standard-features': workspace:^
       '@solana/wallet-standard-util': workspace:^
@@ -124,23 +124,23 @@ importers:
       bs58: ^4.0.1
       shx: ^0.3.4
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.18_@solana+web3.js@1.66.2
+      '@solana/wallet-adapter-base': 0.9.21_@solana+web3.js@1.73.2
       '@solana/wallet-standard-chains': link:../../core/chains
       '@solana/wallet-standard-features': link:../../core/features
       '@solana/wallet-standard-util': link:../../core/util
-      '@wallet-standard/app': 1.0.0
-      '@wallet-standard/base': 1.0.0
-      '@wallet-standard/features': 1.0.0
-      '@wallet-standard/wallet': 1.0.0
+      '@wallet-standard/app': 1.0.1
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.1
+      '@wallet-standard/wallet': 1.0.1
     devDependencies:
-      '@solana/web3.js': 1.66.2
+      '@solana/web3.js': 1.73.2
       '@types/bs58': 4.0.1
       bs58: 4.0.1
       shx: 0.3.4
 
   packages/wallet-adapter/react:
     specifiers:
-      '@solana/wallet-adapter-base': ^0.9.18
+      '@solana/wallet-adapter-base': ^0.9.21
       '@solana/wallet-standard-wallet-adapter-base': workspace:^
       '@types/react': ^18.0.23
       '@wallet-standard/app': ^1.0.0
@@ -149,11 +149,11 @@ importers:
       shx: ^0.3.4
     dependencies:
       '@solana/wallet-standard-wallet-adapter-base': link:../base
-      '@wallet-standard/app': 1.0.0
-      '@wallet-standard/base': 1.0.0
+      '@wallet-standard/app': 1.0.1
+      '@wallet-standard/base': 1.0.1
     devDependencies:
-      '@solana/wallet-adapter-base': 0.9.18_@solana+web3.js@1.66.2
-      '@types/react': 18.0.24
+      '@solana/wallet-adapter-base': 0.9.21_@solana+web3.js@1.73.2
+      '@types/react': 18.0.28
       react: 18.2.0
       shx: 0.3.4
 
@@ -171,16 +171,16 @@ importers:
       typescript: ^4.8.4
     dependencies:
       '@solana/wallet-standard-features': link:../../core/features
-      '@solana/web3.js': 1.66.2
-      '@wallet-standard/base': 1.0.0
-      '@wallet-standard/features': 1.0.0
+      '@solana/web3.js': 1.73.2
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.1
       bs58: 4.0.1
     devDependencies:
       '@types/bs58': 4.0.1
       '@types/node-fetch': 2.6.2
-      prettier: 2.7.1
+      prettier: 2.8.4
       shx: 0.3.4
-      typescript: 4.8.4
+      typescript: 4.9.5
 
   packages/wallets/phantom:
     specifiers:
@@ -196,16 +196,16 @@ importers:
       typescript: ^4.8.4
     dependencies:
       '@solana/wallet-standard-features': link:../../core/features
-      '@solana/web3.js': 1.66.2
-      '@wallet-standard/base': 1.0.0
-      '@wallet-standard/features': 1.0.0
+      '@solana/web3.js': 1.73.2
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.1
       bs58: 4.0.1
     devDependencies:
       '@types/bs58': 4.0.1
       '@types/node-fetch': 2.6.2
-      prettier: 2.7.1
+      prettier: 2.8.4
       shx: 0.3.4
-      typescript: 4.8.4
+      typescript: 4.9.5
 
   packages/wallets/solflare:
     specifiers:
@@ -222,17 +222,17 @@ importers:
       typescript: ^4.8.4
     dependencies:
       '@solana/wallet-standard-features': link:../../core/features
-      '@solana/web3.js': 1.66.2
-      '@solflare-wallet/sdk': 1.1.0_@solana+web3.js@1.66.2
-      '@wallet-standard/base': 1.0.0
-      '@wallet-standard/features': 1.0.0
+      '@solana/web3.js': 1.73.2
+      '@solflare-wallet/sdk': 1.2.0_@solana+web3.js@1.73.2
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.1
       bs58: 4.0.1
     devDependencies:
       '@types/bs58': 4.0.1
       '@types/node-fetch': 2.6.2
-      prettier: 2.7.1
+      prettier: 2.8.4
       shx: 0.3.4
-      typescript: 4.8.4
+      typescript: 4.9.5
 
 packages:
 
@@ -257,65 +257,65 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@babel/runtime/7.20.0:
-    resolution: {integrity: sha512-NDYdls71fTXoU8TZHfbBWg7DiZfNzClcKui/+kyi6ppD2L1qnWW3VV6CjtaBXSUGGhiTWJ6ereOIkUvenif66Q==}
+  /@babel/runtime/7.20.13:
+    resolution: {integrity: sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      regenerator-runtime: 0.13.10
+      regenerator-runtime: 0.13.11
 
-  /@changesets/apply-release-plan/6.1.1:
-    resolution: {integrity: sha512-LaQiP/Wf0zMVR0HNrLQAjz3rsNsr0d/RlnP6Ef4oi8VafOwnY1EoWdK4kssuUJGgNgDyHpomS50dm8CU3D7k7g==}
+  /@changesets/apply-release-plan/6.1.3:
+    resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
     dependencies:
-      '@babel/runtime': 7.20.0
-      '@changesets/config': 2.2.0
+      '@babel/runtime': 7.20.13
+      '@changesets/config': 2.3.0
       '@changesets/get-version-range-type': 0.3.2
-      '@changesets/git': 1.5.0
-      '@changesets/types': 5.2.0
+      '@changesets/git': 2.0.0
+      '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
       detect-indent: 6.1.0
       fs-extra: 7.0.1
       lodash.startcase: 4.4.0
       outdent: 0.5.0
-      prettier: 2.7.1
+      prettier: 2.8.4
       resolve-from: 5.0.0
       semver: 5.7.1
     dev: true
 
-  /@changesets/assemble-release-plan/5.2.2:
-    resolution: {integrity: sha512-B1qxErQd85AeZgZFZw2bDKyOfdXHhG+X5S+W3Da2yCem8l/pRy4G/S7iOpEcMwg6lH8q2ZhgbZZwZ817D+aLuQ==}
+  /@changesets/assemble-release-plan/5.2.3:
+    resolution: {integrity: sha512-g7EVZCmnWz3zMBAdrcKhid4hkHT+Ft1n0mLussFMcB1dE2zCuwcvGoy9ec3yOgPGF4hoMtgHaMIk3T3TBdvU9g==}
     dependencies:
-      '@babel/runtime': 7.20.0
+      '@babel/runtime': 7.20.13
       '@changesets/errors': 0.1.4
-      '@changesets/get-dependents-graph': 1.3.4
-      '@changesets/types': 5.2.0
+      '@changesets/get-dependents-graph': 1.3.5
+      '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
       semver: 5.7.1
     dev: true
 
-  /@changesets/changelog-git/0.1.13:
-    resolution: {integrity: sha512-zvJ50Q+EUALzeawAxax6nF2WIcSsC5PwbuLeWkckS8ulWnuPYx8Fn/Sjd3rF46OzeKA8t30loYYV6TIzp4DIdg==}
+  /@changesets/changelog-git/0.1.14:
+    resolution: {integrity: sha512-+vRfnKtXVWsDDxGctOfzJsPhaCdXRYoe+KyWYoq5X/GqoISREiat0l3L8B0a453B2B4dfHGcZaGyowHbp9BSaA==}
     dependencies:
-      '@changesets/types': 5.2.0
+      '@changesets/types': 5.2.1
     dev: true
 
-  /@changesets/cli/2.25.0:
-    resolution: {integrity: sha512-Svu5KD2enurVHGEEzCRlaojrHjVYgF9srmMP9VQSy9c1TspX6C9lDPpulsSNIjYY9BuU/oiWpjBgR7RI9eQiAA==}
+  /@changesets/cli/2.26.0:
+    resolution: {integrity: sha512-0cbTiDms+ICTVtEwAFLNW0jBNex9f5+fFv3I771nBvdnV/mOjd1QJ4+f8KtVSOrwD9SJkk9xbDkWFb0oXd8d1Q==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.20.0
-      '@changesets/apply-release-plan': 6.1.1
-      '@changesets/assemble-release-plan': 5.2.2
-      '@changesets/changelog-git': 0.1.13
-      '@changesets/config': 2.2.0
+      '@babel/runtime': 7.20.13
+      '@changesets/apply-release-plan': 6.1.3
+      '@changesets/assemble-release-plan': 5.2.3
+      '@changesets/changelog-git': 0.1.14
+      '@changesets/config': 2.3.0
       '@changesets/errors': 0.1.4
-      '@changesets/get-dependents-graph': 1.3.4
-      '@changesets/get-release-plan': 3.0.15
-      '@changesets/git': 1.5.0
+      '@changesets/get-dependents-graph': 1.3.5
+      '@changesets/get-release-plan': 3.0.16
+      '@changesets/git': 2.0.0
       '@changesets/logger': 0.0.5
-      '@changesets/pre': 1.0.13
-      '@changesets/read': 0.5.8
-      '@changesets/types': 5.2.0
-      '@changesets/write': 0.2.1
+      '@changesets/pre': 1.0.14
+      '@changesets/read': 0.5.9
+      '@changesets/types': 5.2.1
+      '@changesets/write': 0.2.3
       '@manypkg/get-packages': 1.1.3
       '@types/is-ci': 3.0.0
       '@types/semver': 6.2.3
@@ -337,13 +337,13 @@ packages:
       tty-table: 4.1.6
     dev: true
 
-  /@changesets/config/2.2.0:
-    resolution: {integrity: sha512-GGaokp3nm5FEDk/Fv2PCRcQCOxGKKPRZ7prcMqxEr7VSsG75MnChQE8plaW1k6V8L2bJE+jZWiRm19LbnproOw==}
+  /@changesets/config/2.3.0:
+    resolution: {integrity: sha512-EgP/px6mhCx8QeaMAvWtRrgyxW08k/Bx2tpGT+M84jEdX37v3VKfh4Cz1BkwrYKuMV2HZKeHOh8sHvja/HcXfQ==}
     dependencies:
       '@changesets/errors': 0.1.4
-      '@changesets/get-dependents-graph': 1.3.4
+      '@changesets/get-dependents-graph': 1.3.5
       '@changesets/logger': 0.0.5
-      '@changesets/types': 5.2.0
+      '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
       micromatch: 4.0.5
@@ -355,25 +355,25 @@ packages:
       extendable-error: 0.1.7
     dev: true
 
-  /@changesets/get-dependents-graph/1.3.4:
-    resolution: {integrity: sha512-+C4AOrrFY146ydrgKOo5vTZfj7vetNu1tWshOID+UjPUU9afYGDXI8yLnAeib1ffeBXV3TuGVcyphKpJ3cKe+A==}
+  /@changesets/get-dependents-graph/1.3.5:
+    resolution: {integrity: sha512-w1eEvnWlbVDIY8mWXqWuYE9oKhvIaBhzqzo4ITSJY9hgoqQ3RoBqwlcAzg11qHxv/b8ReDWnMrpjpKrW6m1ZTA==}
     dependencies:
-      '@changesets/types': 5.2.0
+      '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
       chalk: 2.4.2
       fs-extra: 7.0.1
       semver: 5.7.1
     dev: true
 
-  /@changesets/get-release-plan/3.0.15:
-    resolution: {integrity: sha512-W1tFwxE178/en+zSj/Nqbc3mvz88mcdqUMJhRzN1jDYqN3QI4ifVaRF9mcWUU+KI0gyYEtYR65tour690PqTcA==}
+  /@changesets/get-release-plan/3.0.16:
+    resolution: {integrity: sha512-OpP9QILpBp1bY2YNIKFzwigKh7Qe9KizRsZomzLe6pK8IUo8onkAAVUD8+JRKSr8R7d4+JRuQrfSSNlEwKyPYg==}
     dependencies:
-      '@babel/runtime': 7.20.0
-      '@changesets/assemble-release-plan': 5.2.2
-      '@changesets/config': 2.2.0
-      '@changesets/pre': 1.0.13
-      '@changesets/read': 0.5.8
-      '@changesets/types': 5.2.0
+      '@babel/runtime': 7.20.13
+      '@changesets/assemble-release-plan': 5.2.3
+      '@changesets/config': 2.3.0
+      '@changesets/pre': 1.0.14
+      '@changesets/read': 0.5.9
+      '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
     dev: true
 
@@ -381,14 +381,15 @@ packages:
     resolution: {integrity: sha512-SVqwYs5pULYjYT4op21F2pVbcrca4qA/bAA3FmFXKMN7Y+HcO8sbZUTx3TAy2VXulP2FACd1aC7f2nTuqSPbqg==}
     dev: true
 
-  /@changesets/git/1.5.0:
-    resolution: {integrity: sha512-Xo8AT2G7rQJSwV87c8PwMm6BAc98BnufRMsML7m7Iw8Or18WFvFmxqG5aOL5PBvhgq9KrKvaeIBNIymracSuHg==}
+  /@changesets/git/2.0.0:
+    resolution: {integrity: sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==}
     dependencies:
-      '@babel/runtime': 7.20.0
+      '@babel/runtime': 7.20.13
       '@changesets/errors': 0.1.4
-      '@changesets/types': 5.2.0
+      '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
       is-subdir: 1.2.0
+      micromatch: 4.0.5
       spawndamnit: 2.0.0
     dev: true
 
@@ -398,31 +399,31 @@ packages:
       chalk: 2.4.2
     dev: true
 
-  /@changesets/parse/0.3.15:
-    resolution: {integrity: sha512-3eDVqVuBtp63i+BxEWHPFj2P1s3syk0PTrk2d94W9JD30iG+OER0Y6n65TeLlY8T2yB9Fvj6Ev5Gg0+cKe/ZUA==}
+  /@changesets/parse/0.3.16:
+    resolution: {integrity: sha512-127JKNd167ayAuBjUggZBkmDS5fIKsthnr9jr6bdnuUljroiERW7FBTDNnNVyJ4l69PzR57pk6mXQdtJyBCJKg==}
     dependencies:
-      '@changesets/types': 5.2.0
+      '@changesets/types': 5.2.1
       js-yaml: 3.14.1
     dev: true
 
-  /@changesets/pre/1.0.13:
-    resolution: {integrity: sha512-jrZc766+kGZHDukjKhpBXhBJjVQMied4Fu076y9guY1D3H622NOw8AQaLV3oQsDtKBTrT2AUFjt9Z2Y9Qx+GfA==}
+  /@changesets/pre/1.0.14:
+    resolution: {integrity: sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==}
     dependencies:
-      '@babel/runtime': 7.20.0
+      '@babel/runtime': 7.20.13
       '@changesets/errors': 0.1.4
-      '@changesets/types': 5.2.0
+      '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
     dev: true
 
-  /@changesets/read/0.5.8:
-    resolution: {integrity: sha512-eYaNfxemgX7f7ELC58e7yqQICW5FB7V+bd1lKt7g57mxUrTveYME+JPaBPpYx02nP53XI6CQp6YxnR9NfmFPKw==}
+  /@changesets/read/0.5.9:
+    resolution: {integrity: sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==}
     dependencies:
-      '@babel/runtime': 7.20.0
-      '@changesets/git': 1.5.0
+      '@babel/runtime': 7.20.13
+      '@changesets/git': 2.0.0
       '@changesets/logger': 0.0.5
-      '@changesets/parse': 0.3.15
-      '@changesets/types': 5.2.0
+      '@changesets/parse': 0.3.16
+      '@changesets/types': 5.2.1
       chalk: 2.4.2
       fs-extra: 7.0.1
       p-filter: 2.1.0
@@ -432,29 +433,29 @@ packages:
     resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
     dev: true
 
-  /@changesets/types/5.2.0:
-    resolution: {integrity: sha512-km/66KOqJC+eicZXsm2oq8A8bVTSpkZJ60iPV/Nl5Z5c7p9kk8xxh6XGRTlnludHldxOOfudhnDN2qPxtHmXzA==}
+  /@changesets/types/5.2.1:
+    resolution: {integrity: sha512-myLfHbVOqaq9UtUKqR/nZA/OY7xFjQMdfgfqeZIBK4d0hA6pgxArvdv8M+6NUzzBsjWLOtvApv8YHr4qM+Kpfg==}
     dev: true
 
-  /@changesets/write/0.2.1:
-    resolution: {integrity: sha512-KUd49nt2fnYdGixIqTi1yVE1nAoZYUMdtB3jBfp77IMqjZ65hrmZE5HdccDlTeClZN0420ffpnfET3zzeY8pdw==}
+  /@changesets/write/0.2.3:
+    resolution: {integrity: sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==}
     dependencies:
-      '@babel/runtime': 7.20.0
-      '@changesets/types': 5.2.0
+      '@babel/runtime': 7.20.13
+      '@changesets/types': 5.2.1
       fs-extra: 7.0.1
       human-id: 1.0.2
-      prettier: 2.7.1
+      prettier: 2.8.4
     dev: true
 
-  /@eslint/eslintrc/1.3.3:
-    resolution: {integrity: sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==}
+  /@eslint/eslintrc/1.4.1:
+    resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4
-      espree: 9.4.0
-      globals: 13.17.0
-      ignore: 5.2.0
+      espree: 9.4.1
+      globals: 13.20.0
+      ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -485,7 +486,7 @@ packages:
   /@manypkg/find-root/1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
-      '@babel/runtime': 7.20.0
+      '@babel/runtime': 7.20.13
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -494,7 +495,7 @@ packages:
   /@manypkg/get-packages/1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
-      '@babel/runtime': 7.20.0
+      '@babel/runtime': 7.20.13
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -502,14 +503,14 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
-  /@noble/ed25519/1.7.1:
-    resolution: {integrity: sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==}
+  /@noble/ed25519/1.7.3:
+    resolution: {integrity: sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==}
 
-  /@noble/hashes/1.1.3:
-    resolution: {integrity: sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==}
+  /@noble/hashes/1.2.0:
+    resolution: {integrity: sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==}
 
-  /@noble/secp256k1/1.7.0:
-    resolution: {integrity: sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==}
+  /@noble/secp256k1/1.7.1:
+    resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
 
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -529,44 +530,55 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.13.0
+      fastq: 1.15.0
     dev: true
 
-  /@project-serum/sol-wallet-adapter/0.2.0_@solana+web3.js@1.66.2:
+  /@project-serum/sol-wallet-adapter/0.2.0_@solana+web3.js@1.73.2:
     resolution: {integrity: sha512-ed7wZwlDqjF88VCq7eHVO8njHqdUkBxBL8WEVOnB47ooLO4btOJt6GBdkKpKqKX86c86LiEROJclcdW8e7kIjg==}
     engines: {node: '>=10'}
     peerDependencies:
       '@solana/web3.js': ^1.5.0
     dependencies:
-      '@solana/web3.js': 1.66.2
+      '@solana/web3.js': 1.73.2
       bs58: 4.0.1
       eventemitter3: 4.0.7
     dev: false
 
-  /@solana/buffer-layout/4.0.0:
-    resolution: {integrity: sha512-lR0EMP2HC3+Mxwd4YcnZb0smnaDw7Bl2IQWZiTevRH5ZZBZn6VRWn3/92E3qdU4SSImJkA6IDHawOHAnx/qUvQ==}
+  /@solana/buffer-layout/4.0.1:
+    resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
     engines: {node: '>=5.10'}
     dependencies:
       buffer: 6.0.3
 
-  /@solana/wallet-adapter-base/0.9.18_@solana+web3.js@1.66.2:
-    resolution: {integrity: sha512-5HQFytLmb64j1Nzc6dwddZx+IUePN/PYqVMyf/ok7fN3z8Vw3EIFS8b+RFfBpj4HWbc2kqv5fpnLlaAH7q67pA==}
+  /@solana/wallet-adapter-base/0.9.21_@solana+web3.js@1.73.2:
+    resolution: {integrity: sha512-UPC7GKAMbeoF5Ki+eTi1BHCTjbhtxGIAbgfzSkgYYQKoziDcSr5EgdBL1ntO6wwe6/fRByO6J4q/Dhr7vakz7A==}
     engines: {node: '>=16'}
     peerDependencies:
-      '@solana/web3.js': ^1.61.0
+      '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/web3.js': 1.66.2
+      '@solana/wallet-standard-features': 1.0.0
+      '@solana/web3.js': 1.73.2
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.1
       eventemitter3: 4.0.7
 
-  /@solana/web3.js/1.66.2:
-    resolution: {integrity: sha512-RyaHMR2jGmaesnYP045VLeBGfR/gAW3cvZHzMFGg7bkO+WOYOYp1nEllf0/la4U4qsYGKCsO9eEevR5fhHiVHg==}
+  /@solana/wallet-standard-features/1.0.0:
+    resolution: {integrity: sha512-cZKUm2w67MQOAzbfdZCGAbePWuqSwpvpbWA2K2D0UcHX30I8ry8YEeHlqwqULIOTeY8lRCHu8WMxZwC9iMEqHQ==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.1
+
+  /@solana/web3.js/1.73.2:
+    resolution: {integrity: sha512-9WACF8W4Nstj7xiDw3Oom22QmrhBh0VyZyZ7JvvG3gOxLWLlX3hvm5nPVJOGcCE/9fFavBbCUb5A6CIuvMGdoA==}
     engines: {node: '>=12.20.0'}
     dependencies:
-      '@babel/runtime': 7.20.0
-      '@noble/ed25519': 1.7.1
-      '@noble/hashes': 1.1.3
-      '@noble/secp256k1': 1.7.0
-      '@solana/buffer-layout': 4.0.0
+      '@babel/runtime': 7.20.13
+      '@noble/ed25519': 1.7.3
+      '@noble/hashes': 1.2.0
+      '@noble/secp256k1': 1.7.1
+      '@solana/buffer-layout': 4.0.1
+      agentkeepalive: 4.2.1
       bigint-buffer: 1.1.5
       bn.js: 5.2.1
       borsh: 0.7.0
@@ -574,21 +586,22 @@ packages:
       buffer: 6.0.1
       fast-stable-stringify: 1.0.0
       jayson: 3.7.0
-      node-fetch: 2.6.7
+      node-fetch: 2.6.9
       rpc-websockets: 7.5.0
       superstruct: 0.14.2
     transitivePeerDependencies:
       - bufferutil
       - encoding
+      - supports-color
       - utf-8-validate
 
-  /@solflare-wallet/sdk/1.1.0_@solana+web3.js@1.66.2:
-    resolution: {integrity: sha512-h/OmjgRMDC6CkPHlkUQgOIRv1QXEZp+kQg132zU1KAcikZvc25xf0yMMRU0APUypQ6EJEz6bgQR6BRvvVA9/ZA==}
+  /@solflare-wallet/sdk/1.2.0_@solana+web3.js@1.73.2:
+    resolution: {integrity: sha512-J3KZJdeYJ2R7jPHa0F53iCtkQEdcD1j7yeFQ4oa6Kk6gU1MOqSEWZxrr56sVDKWuPT/gunzEXGrgcwjd7nxwjg==}
     peerDependencies:
       '@solana/web3.js': ^1.61.0
     dependencies:
-      '@project-serum/sol-wallet-adapter': 0.2.0_@solana+web3.js@1.66.2
-      '@solana/web3.js': 1.66.2
+      '@project-serum/sol-wallet-adapter': 0.2.0_@solana+web3.js@1.73.2
+      '@solana/web3.js': 1.73.2
       bs58: 4.0.1
       eventemitter3: 4.0.7
       uuid: 8.3.2
@@ -604,7 +617,7 @@ packages:
     resolution: {integrity: sha512-kmFh1xx7ehXoOVl6OjEBxmiYaquhxCaILjFGwPbW6xwbqzwDKCte+Mzl99aNWg3EP1B4rKVUuRm1vBsiRYks5g==}
     dependencies:
       '@types/filesystem': 0.0.32
-      '@types/har-format': 1.2.9
+      '@types/har-format': 1.2.10
     dev: true
 
   /@types/connect/3.4.35:
@@ -622,14 +635,14 @@ packages:
     resolution: {integrity: sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==}
     dev: true
 
-  /@types/har-format/1.2.9:
-    resolution: {integrity: sha512-rffW6MhQ9yoa75bdNi+rjZBAvu2HhehWJXlhuWXnWdENeuKe82wUgAwxYOb7KRKKmxYN+D/iRKd2NDQMLqlUmg==}
+  /@types/har-format/1.2.10:
+    resolution: {integrity: sha512-o0J30wqycjF5miWDKYKKzzOU1ZTLuA42HZ4HE7/zqTOc/jTLdQ5NhYWvsRQo45Nfi1KHoRdNhteSI4BAxTF1Pg==}
     dev: true
 
   /@types/is-ci/3.0.0:
     resolution: {integrity: sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==}
     dependencies:
-      ci-info: 3.5.0
+      ci-info: 3.8.0
     dev: true
 
   /@types/json-schema/7.0.11:
@@ -643,15 +656,15 @@ packages:
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 18.11.7
+      '@types/node': 18.14.0
       form-data: 3.0.1
     dev: true
 
   /@types/node/12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  /@types/node/18.11.7:
-    resolution: {integrity: sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==}
+  /@types/node/18.14.0:
+    resolution: {integrity: sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -662,8 +675,8 @@ packages:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
     dev: true
 
-  /@types/react/18.0.24:
-    resolution: {integrity: sha512-wRJWT6ouziGUy+9uX0aW4YOJxAY0bG6/AOk5AW5QSvZqI7dk6VBIbXvcVgIw/W5Jrl24f77df98GEKTJGOLx7Q==}
+  /@types/react/18.0.28:
+    resolution: {integrity: sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -687,8 +700,8 @@ packages:
     dependencies:
       '@types/node': 12.20.55
 
-  /@typescript-eslint/eslint-plugin/5.41.0_rydi7wwjgn4gtr73oslg4mokxa:
-    resolution: {integrity: sha512-DXUS22Y57/LAFSg3x7Vi6RNAuLpTXwxB9S2nIA7msBb/Zt8p7XqMwdpdc1IU7CkOQUPgAqR5fWvxuKCbneKGmA==}
+  /@typescript-eslint/eslint-plugin/5.52.0_44oiodj6oihskayaxpgdr6lwb4:
+    resolution: {integrity: sha512-lHazYdvYVsBokwCdKOppvYJKaJ4S41CgKBcPvyd0xjZNbvQdhn/pnJlGtQksQ/NhInzdaeaSarlBjDXHuclEbg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -698,13 +711,15 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.41.0_4rv7y5c6xz3vfxwhbrcxxi73bq
-      '@typescript-eslint/scope-manager': 5.41.0
-      '@typescript-eslint/type-utils': 5.41.0_4rv7y5c6xz3vfxwhbrcxxi73bq
-      '@typescript-eslint/utils': 5.41.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/parser': 5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/scope-manager': 5.52.0
+      '@typescript-eslint/type-utils': 5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/utils': 5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq
       debug: 4.3.4
       eslint: 8.22.0
-      ignore: 5.2.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.4
+      natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
       tsutils: 3.21.0_typescript@4.7.4
@@ -713,8 +728,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.41.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
-    resolution: {integrity: sha512-HQVfix4+RL5YRWZboMD1pUfFN8MpRH4laziWkkAzyO1fvNOY/uinZcvo3QiFJVS/siNHupV8E5+xSwQZrl6PZA==}
+  /@typescript-eslint/parser/5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
+    resolution: {integrity: sha512-e2KiLQOZRo4Y0D/b+3y08i3jsekoSkOYStROYmPUnGMEoA0h+k2qOH5H6tcjIc68WDvGwH+PaOrP1XRzLJ6QlA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -723,9 +738,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.41.0
-      '@typescript-eslint/types': 5.41.0
-      '@typescript-eslint/typescript-estree': 5.41.0_typescript@4.7.4
+      '@typescript-eslint/scope-manager': 5.52.0
+      '@typescript-eslint/types': 5.52.0
+      '@typescript-eslint/typescript-estree': 5.52.0_typescript@4.7.4
       debug: 4.3.4
       eslint: 8.22.0
       typescript: 4.7.4
@@ -733,16 +748,16 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager/5.41.0:
-    resolution: {integrity: sha512-xOxPJCnuktUkY2xoEZBKXO5DBCugFzjrVndKdUnyQr3+9aDWZReKq9MhaoVnbL+maVwWJu/N0SEtrtEUNb62QQ==}
+  /@typescript-eslint/scope-manager/5.52.0:
+    resolution: {integrity: sha512-AR7sxxfBKiNV0FWBSARxM8DmNxrwgnYMPwmpkC1Pl1n+eT8/I2NAUPuwDy/FmDcC6F8pBfmOcaxcxRHspgOBMw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.41.0
-      '@typescript-eslint/visitor-keys': 5.41.0
+      '@typescript-eslint/types': 5.52.0
+      '@typescript-eslint/visitor-keys': 5.52.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.41.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
-    resolution: {integrity: sha512-L30HNvIG6A1Q0R58e4hu4h+fZqaO909UcnnPbwKiN6Rc3BUEx6ez2wgN7aC0cBfcAjZfwkzE+E2PQQ9nEuoqfA==}
+  /@typescript-eslint/type-utils/5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
+    resolution: {integrity: sha512-tEKuUHfDOv852QGlpPtB3lHOoig5pyFQN/cUiZtpw99D93nEBjexRLre5sQZlkMoHry/lZr8qDAt2oAHLKA6Jw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -751,8 +766,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.41.0_typescript@4.7.4
-      '@typescript-eslint/utils': 5.41.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/typescript-estree': 5.52.0_typescript@4.7.4
+      '@typescript-eslint/utils': 5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq
       debug: 4.3.4
       eslint: 8.22.0
       tsutils: 3.21.0_typescript@4.7.4
@@ -761,13 +776,13 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types/5.41.0:
-    resolution: {integrity: sha512-5BejraMXMC+2UjefDvrH0Fo/eLwZRV6859SXRg+FgbhA0R0l6lDqDGAQYhKbXhPN2ofk2kY5sgGyLNL907UXpA==}
+  /@typescript-eslint/types/5.52.0:
+    resolution: {integrity: sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.41.0_typescript@4.7.4:
-    resolution: {integrity: sha512-SlzFYRwFSvswzDSQ/zPkIWcHv8O5y42YUskko9c4ki+fV6HATsTODUPbRbcGDFYP86gaJL5xohUEytvyNNcXWg==}
+  /@typescript-eslint/typescript-estree/5.52.0_typescript@4.7.4:
+    resolution: {integrity: sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -775,8 +790,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.41.0
-      '@typescript-eslint/visitor-keys': 5.41.0
+      '@typescript-eslint/types': 5.52.0
+      '@typescript-eslint/visitor-keys': 5.52.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -787,17 +802,17 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.41.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
-    resolution: {integrity: sha512-QlvfwaN9jaMga9EBazQ+5DDx/4sAdqDkcs05AsQHMaopluVCUyu1bTRUVKzXbgjDlrRAQrYVoi/sXJ9fmG+KLQ==}
+  /@typescript-eslint/utils/5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
+    resolution: {integrity: sha512-As3lChhrbwWQLNk2HC8Ree96hldKIqk98EYvypd3It8Q1f8d5zWyIoaZEp2va5667M4ZyE7X8UUR+azXrFl+NA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@types/json-schema': 7.0.11
       '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.41.0
-      '@typescript-eslint/types': 5.41.0
-      '@typescript-eslint/typescript-estree': 5.41.0_typescript@4.7.4
+      '@typescript-eslint/scope-manager': 5.52.0
+      '@typescript-eslint/types': 5.52.0
+      '@typescript-eslint/typescript-estree': 5.52.0_typescript@4.7.4
       eslint: 8.22.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.22.0
@@ -807,38 +822,36 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys/5.41.0:
-    resolution: {integrity: sha512-vilqeHj267v8uzzakbm13HkPMl7cbYpKVjgFWZPIOHIJHZtinvypUhJ5xBXfWYg4eFKqztbMMpOgFpT9Gfx4fw==}
+  /@typescript-eslint/visitor-keys/5.52.0:
+    resolution: {integrity: sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.41.0
+      '@typescript-eslint/types': 5.52.0
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@wallet-standard/app/1.0.0:
-    resolution: {integrity: sha512-ElUzbW0QpqNEVcjfak1oE/abd0CgjXH2URJmj60VjSx5/g30HPZxynfBAyUV3EiSPyvo4CgM1HyLQ73Y+cDy3w==}
+  /@wallet-standard/app/1.0.1:
+    resolution: {integrity: sha512-LnLYq2Vy2guTZ8GQKKSXQK3+FRGPil75XEdkZqE6fiLixJhZJoJa5hT7lXxwe0ykVTt9LEThdTbOpT7KadS26Q==}
     engines: {node: '>=16'}
     dependencies:
-      '@wallet-standard/base': 1.0.0
+      '@wallet-standard/base': 1.0.1
     dev: false
 
-  /@wallet-standard/base/1.0.0:
-    resolution: {integrity: sha512-MxGmm4vFvz2zZ/NPphdsQxSsAEtHMFSgDLqo6WNaI0w1MLxj1S93cRIjhHCn7Ny7lpNJ6jVEZqhB3F/dqRkFlg==}
+  /@wallet-standard/base/1.0.1:
+    resolution: {integrity: sha512-1To3ekMfzhYxe0Yhkpri+Fedq0SYcfrOfJi3vbLjMwF2qiKPjTGLwZkf2C9ftdQmxES+hmxhBzTwF4KgcOwf8w==}
     engines: {node: '>=16'}
-    dev: false
 
-  /@wallet-standard/features/1.0.0:
-    resolution: {integrity: sha512-t0Fr+ds2e1L53NoIht8jLAt2pZJYupOouI9ztk4DEXRWZAC+iiPvIrH/fqI2YKmsfvNBRn6hUVsd3UsV3Uw3Sg==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@wallet-standard/base': 1.0.0
-    dev: false
-
-  /@wallet-standard/wallet/1.0.0:
-    resolution: {integrity: sha512-w+eiUj05Z0JCXYFEuFvzy6IkdAC46VvVe7nl33FPQ2MUmCfDTX7Q39dIOtf6g8yM+O3fzFNlvnTcuXgcqqmRrg==}
+  /@wallet-standard/features/1.0.1:
+    resolution: {integrity: sha512-B/WzRpoEiGQ+kwL/AuzqzNjrGvdL5J2OXiXHkDGONsNbKdtTpExU+ttZKQwSP/EvPl8+ZZ/4OO/Bz4YkigtQDg==}
     engines: {node: '>=16'}
     dependencies:
-      '@wallet-standard/base': 1.0.0
+      '@wallet-standard/base': 1.0.1
+
+  /@wallet-standard/wallet/1.0.1:
+    resolution: {integrity: sha512-qkhJeuQU2afQTZ02yMZE5SFc91Fo3hyFjFkpQglHudENNyiSG0oUKcIjky8X32xVSaumgTZSQUAzpXnCTWHzKQ==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@wallet-standard/base': 1.0.1
     dev: false
 
   /JSONStream/1.3.5:
@@ -848,19 +861,29 @@ packages:
       jsonparse: 1.3.1
       through: 2.3.8
 
-  /acorn-jsx/5.3.2_acorn@8.8.1:
+  /acorn-jsx/5.3.2_acorn@8.8.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.8.2
     dev: true
 
-  /acorn/8.8.1:
-    resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
+  /acorn/8.8.2:
+    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
+
+  /agentkeepalive/4.2.1:
+    resolution: {integrity: sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      debug: 4.3.4
+      depd: 1.1.2
+      humanize-ms: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   /ajv/6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -879,6 +902,10 @@ packages:
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+    dev: true
+
+  /ansi-sequence-parser/1.1.0:
+    resolution: {integrity: sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==}
     dev: true
 
   /ansi-styles/3.2.1:
@@ -905,14 +932,14 @@ packages:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
 
-  /array-includes/3.1.5:
-    resolution: {integrity: sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==}
+  /array-includes/3.1.6:
+    resolution: {integrity: sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
-      get-intrinsic: 1.1.3
+      define-properties: 1.2.0
+      es-abstract: 1.21.1
+      get-intrinsic: 1.2.0
       is-string: 1.0.7
     dev: true
 
@@ -933,24 +960,34 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /array.prototype.flat/1.3.0:
-    resolution: {integrity: sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==}
+  /array.prototype.flat/1.3.1:
+    resolution: {integrity: sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
+      define-properties: 1.2.0
+      es-abstract: 1.21.1
       es-shim-unscopables: 1.0.0
     dev: true
 
-  /array.prototype.flatmap/1.3.0:
-    resolution: {integrity: sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==}
+  /array.prototype.flatmap/1.3.1:
+    resolution: {integrity: sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
+      define-properties: 1.2.0
+      es-abstract: 1.21.1
       es-shim-unscopables: 1.0.0
+    dev: true
+
+  /array.prototype.tosorted/1.1.1:
+    resolution: {integrity: sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.21.1
+      es-shim-unscopables: 1.0.0
+      get-intrinsic: 1.2.0
     dev: true
 
   /arrify/1.0.1:
@@ -966,6 +1003,11 @@ packages:
 
   /asynckit/0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: true
+
+  /available-typed-arrays/1.0.5:
+    resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /balanced-match/1.0.2:
@@ -1057,13 +1099,13 @@ packages:
     engines: {node: '>=6.14.2'}
     requiresBuild: true
     dependencies:
-      node-gyp-build: 4.5.0
+      node-gyp-build: 4.6.0
 
   /call-bind/1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
       function-bind: 1.1.1
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: true
 
   /callsites/3.1.0:
@@ -1106,8 +1148,9 @@ packages:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
     dev: true
 
-  /ci-info/3.5.0:
-    resolution: {integrity: sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==}
+  /ci-info/3.8.0:
+    resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
+    engines: {node: '>=8'}
     dev: true
 
   /cliui/6.0.0:
@@ -1224,10 +1267,9 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
-  /decamelize-keys/1.1.0:
-    resolution: {integrity: sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==}
+  /decamelize-keys/1.1.1:
+    resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       decamelize: 1.2.0
@@ -1249,8 +1291,8 @@ packages:
       clone: 1.0.4
     dev: true
 
-  /define-properties/1.1.4:
-    resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==}
+  /define-properties/1.2.0:
+    resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-property-descriptors: 1.0.0
@@ -1265,6 +1307,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
     dev: true
+
+  /depd/1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
 
   /detect-indent/6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -1313,34 +1359,52 @@ packages:
       is-arrayish: 0.2.1
     dev: true
 
-  /es-abstract/1.20.4:
-    resolution: {integrity: sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==}
+  /es-abstract/1.21.1:
+    resolution: {integrity: sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==}
     engines: {node: '>= 0.4'}
     dependencies:
+      available-typed-arrays: 1.0.5
       call-bind: 1.0.2
+      es-set-tostringtag: 2.0.1
       es-to-primitive: 1.2.1
       function-bind: 1.1.1
       function.prototype.name: 1.1.5
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       get-symbol-description: 1.0.0
+      globalthis: 1.0.3
+      gopd: 1.0.1
       has: 1.0.3
       has-property-descriptors: 1.0.0
+      has-proto: 1.0.1
       has-symbols: 1.0.3
-      internal-slot: 1.0.3
+      internal-slot: 1.0.5
+      is-array-buffer: 3.0.1
       is-callable: 1.2.7
       is-negative-zero: 2.0.2
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
       is-string: 1.0.7
+      is-typed-array: 1.1.10
       is-weakref: 1.0.2
-      object-inspect: 1.12.2
+      object-inspect: 1.12.3
       object-keys: 1.1.1
       object.assign: 4.1.4
       regexp.prototype.flags: 1.4.3
       safe-regex-test: 1.0.0
-      string.prototype.trimend: 1.0.5
-      string.prototype.trimstart: 1.0.5
+      string.prototype.trimend: 1.0.6
+      string.prototype.trimstart: 1.0.6
+      typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
+      which-typed-array: 1.1.9
+    dev: true
+
+  /es-set-tostringtag/2.0.1:
+    resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.0
+      has: 1.0.3
+      has-tostringtag: 1.0.0
     dev: true
 
   /es-shim-unscopables/1.0.0:
@@ -1381,8 +1445,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-prettier/8.5.0_eslint@8.22.0:
-    resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
+  /eslint-config-prettier/8.6.0_eslint@8.22.0:
+    resolution: {integrity: sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -1390,7 +1454,7 @@ packages:
       eslint: 8.22.0
     dev: true
 
-  /eslint-plugin-prettier/4.2.1_i2cojdczqdiurzgttlwdgf764e:
+  /eslint-plugin-prettier/4.2.1_qt54dw5ublwxu5wgrb6fweerp4:
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1402,8 +1466,8 @@ packages:
         optional: true
     dependencies:
       eslint: 8.22.0
-      eslint-config-prettier: 8.5.0_eslint@8.22.0
-      prettier: 2.7.1
+      eslint-config-prettier: 8.6.0_eslint@8.22.0
+      prettier: 2.8.4
       prettier-linter-helpers: 1.0.0
     dev: true
 
@@ -1416,31 +1480,32 @@ packages:
       eslint: 8.22.0
     dev: true
 
-  /eslint-plugin-react/7.31.10_eslint@8.22.0:
-    resolution: {integrity: sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==}
+  /eslint-plugin-react/7.32.2_eslint@8.22.0:
+    resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
-      array-includes: 3.1.5
-      array.prototype.flatmap: 1.3.0
+      array-includes: 3.1.6
+      array.prototype.flatmap: 1.3.1
+      array.prototype.tosorted: 1.1.1
       doctrine: 2.1.0
       eslint: 8.22.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.3
       minimatch: 3.1.2
-      object.entries: 1.1.5
-      object.fromentries: 2.0.5
-      object.hasown: 1.1.1
-      object.values: 1.1.5
+      object.entries: 1.1.6
+      object.fromentries: 2.0.6
+      object.hasown: 1.1.2
+      object.values: 1.1.6
       prop-types: 15.8.1
       resolve: 2.0.0-next.4
       semver: 6.3.0
-      string.prototype.matchall: 4.0.7
+      string.prototype.matchall: 4.0.8
     dev: true
 
-  /eslint-plugin-require-extensions/0.1.1_eslint@8.22.0:
-    resolution: {integrity: sha512-qSF0vPCxFck0ady5QmPc57ehGbJkqNBXFaBOrGD6XoLFckLdxxraNVj9P4JOxa9AefIhsLJVe3YMGBhrg4bG0A==}
+  /eslint-plugin-require-extensions/0.1.2_eslint@8.22.0:
+    resolution: {integrity: sha512-UtddVQMdE2SezgWwK7JO7eCBUDUqLg6jq8YGlz5RlSG06Sqlr+xcAaosho3wZYrOzfp6zKUseDFavWgoAgCimQ==}
     engines: {node: '>=16'}
     peerDependencies:
       eslint: '*'
@@ -1489,7 +1554,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint/eslintrc': 1.3.3
+      '@eslint/eslintrc': 1.4.1
       '@humanwhocodes/config-array': 0.10.7
       '@humanwhocodes/gitignore-to-minimatch': 1.0.2
       ajv: 6.12.6
@@ -1501,18 +1566,18 @@ packages:
       eslint-scope: 7.1.1
       eslint-utils: 3.0.0_eslint@8.22.0
       eslint-visitor-keys: 3.3.0
-      espree: 9.4.0
-      esquery: 1.4.0
+      espree: 9.4.1
+      esquery: 1.4.2
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       functional-red-black-tree: 1.0.1
       glob-parent: 6.0.2
-      globals: 13.17.0
+      globals: 13.20.0
       globby: 11.1.0
       grapheme-splitter: 1.0.4
-      ignore: 5.2.0
+      ignore: 5.2.4
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
@@ -1532,12 +1597,12 @@ packages:
       - supports-color
     dev: true
 
-  /espree/9.4.0:
-    resolution: {integrity: sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==}
+  /espree/9.4.1:
+    resolution: {integrity: sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.8.1
-      acorn-jsx: 5.3.2_acorn@8.8.1
+      acorn: 8.8.2
+      acorn-jsx: 5.3.2_acorn@8.8.2
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -1547,8 +1612,8 @@ packages:
     hasBin: true
     dev: true
 
-  /esquery/1.4.0:
-    resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
+  /esquery/1.4.2:
+    resolution: {integrity: sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==}
     engines: {node: '>=0.10'}
     dependencies:
       estraverse: 5.3.0
@@ -1626,8 +1691,8 @@ packages:
   /fast-stable-stringify/1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
-  /fastq/1.13.0:
-    resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
+  /fastq/1.15.0:
+    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
       reusify: 1.0.4
     dev: true
@@ -1707,6 +1772,12 @@ packages:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
 
+  /for-each/0.3.3:
+    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
+    dependencies:
+      is-callable: 1.2.7
+    dev: true
+
   /form-data/3.0.1:
     resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
     engines: {node: '>= 6'}
@@ -1747,8 +1818,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
+      define-properties: 1.2.0
+      es-abstract: 1.21.1
       functions-have-names: 1.2.3
     dev: true
 
@@ -1765,8 +1836,8 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dev: true
 
-  /get-intrinsic/1.1.3:
-    resolution: {integrity: sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==}
+  /get-intrinsic/1.2.0:
+    resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
@@ -1778,7 +1849,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: true
 
   /gh-pages/4.0.0:
@@ -1820,11 +1891,18 @@ packages:
       path-is-absolute: 1.0.1
     dev: true
 
-  /globals/13.17.0:
-    resolution: {integrity: sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==}
+  /globals/13.20.0:
+    resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
+    dev: true
+
+  /globalthis/1.0.3:
+    resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-properties: 1.2.0
     dev: true
 
   /globby/11.1.0:
@@ -1834,7 +1912,7 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.2.12
-      ignore: 5.2.0
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -1848,6 +1926,12 @@ packages:
       object-assign: 4.1.1
       pify: 2.3.0
       pinkie-promise: 2.0.1
+    dev: true
+
+  /gopd/1.0.1:
+    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+    dependencies:
+      get-intrinsic: 1.2.0
     dev: true
 
   /graceful-fs/4.2.10:
@@ -1880,7 +1964,12 @@ packages:
   /has-property-descriptors/1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
+    dev: true
+
+  /has-proto/1.0.1:
+    resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /has-symbols/1.0.3:
@@ -1910,6 +1999,11 @@ packages:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
     dev: true
 
+  /humanize-ms/1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+    dependencies:
+      ms: 2.1.3
+
   /iconv-lite/0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -1920,8 +2014,8 @@ packages:
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  /ignore/5.2.0:
-    resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
+  /ignore/5.2.4:
+    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
     dev: true
 
@@ -1954,11 +2048,11 @@ packages:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
     dev: true
 
-  /internal-slot/1.0.3:
-    resolution: {integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==}
+  /internal-slot/1.0.5:
+    resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       has: 1.0.3
       side-channel: 1.0.4
     dev: true
@@ -1966,6 +2060,14 @@ packages:
   /interpret/1.4.0:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
     engines: {node: '>= 0.10'}
+    dev: true
+
+  /is-array-buffer/3.0.1:
+    resolution: {integrity: sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.0
+      is-typed-array: 1.1.10
     dev: true
 
   /is-arrayish/0.2.1:
@@ -1995,7 +2097,7 @@ packages:
     resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
     hasBin: true
     dependencies:
-      ci-info: 3.5.0
+      ci-info: 3.8.0
     dev: true
 
   /is-core-module/2.11.0:
@@ -2085,6 +2187,17 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
+  /is-typed-array/1.1.10:
+    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
+    dev: true
+
   /is-weakref/1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
@@ -2115,13 +2228,13 @@ packages:
       '@types/connect': 3.4.35
       '@types/node': 12.20.55
       '@types/ws': 7.4.7
-      JSONStream: 1.3.5
       commander: 2.20.3
       delay: 5.0.0
       es6-promisify: 5.0.0
       eyes: 0.1.8
       isomorphic-ws: 4.0.1_ws@7.5.9
       json-stringify-safe: 5.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       uuid: 8.3.2
       ws: 7.5.9
@@ -2181,7 +2294,7 @@ packages:
     resolution: {integrity: sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==}
     engines: {node: '>=4.0'}
     dependencies:
-      array-includes: 3.1.5
+      array-includes: 3.1.6
       object.assign: 4.1.4
     dev: true
 
@@ -2284,8 +2397,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /marked/4.1.1:
-    resolution: {integrity: sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw==}
+  /marked/4.2.12:
+    resolution: {integrity: sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==}
     engines: {node: '>= 12'}
     hasBin: true
     dev: true
@@ -2296,7 +2409,7 @@ packages:
     dependencies:
       '@types/minimist': 1.2.2
       camelcase-keys: 6.2.2
-      decamelize-keys: 1.1.0
+      decamelize-keys: 1.1.1
       hard-rejection: 2.1.0
       minimist-options: 4.1.0
       normalize-package-data: 2.5.0
@@ -2343,8 +2456,8 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
-  /minimatch/5.1.0:
-    resolution: {integrity: sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==}
+  /minimatch/6.2.0:
+    resolution: {integrity: sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==}
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
@@ -2359,25 +2472,31 @@ packages:
       kind-of: 6.0.3
     dev: true
 
-  /minimist/1.2.7:
-    resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
+  /minimist/1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
 
-  /mixme/0.5.4:
-    resolution: {integrity: sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw==}
+  /mixme/0.5.5:
+    resolution: {integrity: sha512-/6IupbRx32s7jjEwHcycXikJwFD5UujbVNuJFkeKLYje+92OvtuPniF6JhnFm5JCTDUhS+kYK3W/4BWYQYXz7w==}
     engines: {node: '>= 8.0.0'}
     dev: true
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  /ms/2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  /natural-compare-lite/1.4.0:
+    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /node-fetch/2.6.7:
-    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+  /node-fetch/2.6.9:
+    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0
@@ -2387,8 +2506,8 @@ packages:
     dependencies:
       whatwg-url: 5.0.0
 
-  /node-gyp-build/4.5.0:
-    resolution: {integrity: sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==}
+  /node-gyp-build/4.6.0:
+    resolution: {integrity: sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==}
     hasBin: true
 
   /normalize-package-data/2.5.0:
@@ -2405,8 +2524,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /object-inspect/1.12.2:
-    resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
+  /object-inspect/1.12.3:
+    resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
     dev: true
 
   /object-keys/1.1.1:
@@ -2419,43 +2538,43 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       has-symbols: 1.0.3
       object-keys: 1.1.1
     dev: true
 
-  /object.entries/1.1.5:
-    resolution: {integrity: sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==}
+  /object.entries/1.1.6:
+    resolution: {integrity: sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
+      define-properties: 1.2.0
+      es-abstract: 1.21.1
     dev: true
 
-  /object.fromentries/2.0.5:
-    resolution: {integrity: sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==}
+  /object.fromentries/2.0.6:
+    resolution: {integrity: sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
+      define-properties: 1.2.0
+      es-abstract: 1.21.1
     dev: true
 
-  /object.hasown/1.1.1:
-    resolution: {integrity: sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==}
+  /object.hasown/1.1.2:
+    resolution: {integrity: sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==}
     dependencies:
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
+      define-properties: 1.2.0
+      es-abstract: 1.21.1
     dev: true
 
-  /object.values/1.1.5:
-    resolution: {integrity: sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==}
+  /object.values/1.1.6:
+    resolution: {integrity: sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
+      define-properties: 1.2.0
+      es-abstract: 1.21.1
     dev: true
 
   /once/1.4.0:
@@ -2605,8 +2724,8 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /pnpm/7.14.0:
-    resolution: {integrity: sha512-yUKSckJLBIw8ByqMKJF9497kzwrevuQhdL6o2eYbky7woAictxoGX9veBdQYCdBemuC239X2FJq/LGTpCjQ55w==}
+  /pnpm/7.27.1:
+    resolution: {integrity: sha512-IpBeZ+71slENbuOXwbV4U6yxOMfEWEvlVuT6+ChZ1D80oF0eHyN4h/hc13UrzVXpXI3bf7sPfRWGb8TYkrvJUA==}
     engines: {node: '>=14.6'}
     hasBin: true
     dev: true
@@ -2633,8 +2752,8 @@ packages:
       fast-diff: 1.2.0
     dev: true
 
-  /prettier/2.7.1:
-    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
+  /prettier/2.8.4:
+    resolution: {integrity: sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
@@ -2651,8 +2770,8 @@ packages:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
     dev: true
 
-  /punycode/2.1.1:
-    resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
+  /punycode/2.3.0:
+    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
     dev: true
 
@@ -2720,15 +2839,15 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
-  /regenerator-runtime/0.13.10:
-    resolution: {integrity: sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==}
+  /regenerator-runtime/0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   /regexp.prototype.flags/1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       functions-have-names: 1.2.3
     dev: true
 
@@ -2789,10 +2908,10 @@ packages:
   /rpc-websockets/7.5.0:
     resolution: {integrity: sha512-9tIRi1uZGy7YmDjErf1Ax3wtqdSSLIlnmL5OtOzgd5eqPKbsPpwDP5whUDO2LQay3Xp0CcHlcNSGzacNRluBaQ==}
     dependencies:
-      '@babel/runtime': 7.20.0
+      '@babel/runtime': 7.20.13
       eventemitter3: 4.0.7
       uuid: 8.3.2
-      ws: 8.10.0_3cxu5zja4e2r5wmvge7mdcljwq
+      ws: 8.12.1_3cxu5zja4e2r5wmvge7mdcljwq
     optionalDependencies:
       bufferutil: 4.0.7
       utf-8-validate: 5.0.10
@@ -2810,7 +2929,7 @@ packages:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       is-regex: 1.1.4
     dev: true
 
@@ -2874,12 +2993,13 @@ packages:
       rechoir: 0.6.2
     dev: true
 
-  /shiki/0.11.1:
-    resolution: {integrity: sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==}
+  /shiki/0.14.1:
+    resolution: {integrity: sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==}
     dependencies:
+      ansi-sequence-parser: 1.1.0
       jsonc-parser: 3.2.0
-      vscode-oniguruma: 1.6.2
-      vscode-textmate: 6.0.0
+      vscode-oniguruma: 1.7.0
+      vscode-textmate: 8.0.0
     dev: true
 
   /shx/0.3.4:
@@ -2887,7 +3007,7 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
     dependencies:
-      minimist: 1.2.7
+      minimist: 1.2.8
       shelljs: 0.8.5
     dev: true
 
@@ -2895,8 +3015,8 @@ packages:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
-      object-inspect: 1.12.2
+      get-intrinsic: 1.2.0
+      object-inspect: 1.12.3
     dev: true
 
   /signal-exit/3.0.7:
@@ -2913,7 +3033,7 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
     dependencies:
-      array.prototype.flat: 1.3.0
+      array.prototype.flat: 1.3.1
       breakword: 1.0.5
       grapheme-splitter: 1.0.4
       strip-ansi: 6.0.1
@@ -2957,7 +3077,7 @@ packages:
   /stream-transform/2.1.3:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}
     dependencies:
-      mixme: 0.5.4
+      mixme: 0.5.5
     dev: true
 
   /string-width/4.2.3:
@@ -2969,33 +3089,33 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /string.prototype.matchall/4.0.7:
-    resolution: {integrity: sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==}
+  /string.prototype.matchall/4.0.8:
+    resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
-      get-intrinsic: 1.1.3
+      define-properties: 1.2.0
+      es-abstract: 1.21.1
+      get-intrinsic: 1.2.0
       has-symbols: 1.0.3
-      internal-slot: 1.0.3
+      internal-slot: 1.0.5
       regexp.prototype.flags: 1.4.3
       side-channel: 1.0.4
     dev: true
 
-  /string.prototype.trimend/1.0.5:
-    resolution: {integrity: sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==}
+  /string.prototype.trimend/1.0.6:
+    resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
+      define-properties: 1.2.0
+      es-abstract: 1.21.1
     dev: true
 
-  /string.prototype.trimstart/1.0.5:
-    resolution: {integrity: sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==}
+  /string.prototype.trimstart/1.0.6:
+    resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
+      define-properties: 1.2.0
+      es-abstract: 1.21.1
     dev: true
 
   /strip-ansi/6.0.1:
@@ -3120,7 +3240,7 @@ packages:
       smartwrap: 2.0.2
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
-      yargs: 17.6.0
+      yargs: 17.7.0
     dev: true
 
   /type-check/0.4.0:
@@ -3150,17 +3270,25 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /typedoc/0.23.19_typescript@4.7.4:
-    resolution: {integrity: sha512-70jPL0GQnSJtgQqI7ifOWxpTXrB3sxc4SWPPRn3K0wdx3txI6ZIT/ZYMF39dNg2Gjmql45cO+cAKXJp0TpqOVA==}
+  /typed-array-length/1.0.4:
+    resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
+    dependencies:
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      is-typed-array: 1.1.10
+    dev: true
+
+  /typedoc/0.23.25_typescript@4.7.4:
+    resolution: {integrity: sha512-O1he153qVyoCgJYSvIyY3bPP1wAJTegZfa6tL3APinSZhJOf8CSd8F/21M6ex8pUY/fuY6n0jAsT4fIuMGA6sA==}
     engines: {node: '>= 14.14'}
     hasBin: true
     peerDependencies:
-      typescript: 4.6.x || 4.7.x || 4.8.x
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x
     dependencies:
       lunr: 2.3.9
-      marked: 4.1.1
-      minimatch: 5.1.0
-      shiki: 0.11.1
+      marked: 4.2.12
+      minimatch: 6.2.0
+      shiki: 0.14.1
       typescript: 4.7.4
     dev: true
 
@@ -3170,8 +3298,8 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript/4.8.4:
-    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
+  /typescript/4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
@@ -3193,7 +3321,7 @@ packages:
   /uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
-      punycode: 2.1.1
+      punycode: 2.3.0
     dev: true
 
   /utf-8-validate/5.0.10:
@@ -3201,7 +3329,7 @@ packages:
     engines: {node: '>=6.14.2'}
     requiresBuild: true
     dependencies:
-      node-gyp-build: 4.5.0
+      node-gyp-build: 4.6.0
 
   /uuid/8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -3218,12 +3346,12 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vscode-oniguruma/1.6.2:
-    resolution: {integrity: sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==}
+  /vscode-oniguruma/1.7.0:
+    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
     dev: true
 
-  /vscode-textmate/6.0.0:
-    resolution: {integrity: sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==}
+  /vscode-textmate/8.0.0:
+    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
     dev: true
 
   /wcwidth/1.0.1:
@@ -3261,6 +3389,18 @@ packages:
     dependencies:
       load-yaml-file: 0.2.0
       path-exists: 4.0.0
+    dev: true
+
+  /which-typed-array/1.1.9:
+    resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
+      is-typed-array: 1.1.10
     dev: true
 
   /which/1.3.1:
@@ -3317,12 +3457,12 @@ packages:
       utf-8-validate:
         optional: true
 
-  /ws/8.10.0_3cxu5zja4e2r5wmvge7mdcljwq:
-    resolution: {integrity: sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==}
+  /ws/8.12.1_3cxu5zja4e2r5wmvge7mdcljwq:
+    resolution: {integrity: sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -3379,8 +3519,8 @@ packages:
       yargs-parser: 18.1.3
     dev: true
 
-  /yargs/17.6.0:
-    resolution: {integrity: sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==}
+  /yargs/17.7.0:
+    resolution: {integrity: sha512-dwqOPg5trmrre9+v8SUo2q/hAwyKoVfu8OC1xPHKJGNdxAvPl4sKxL4vBnh3bQz/ZvvGAFeA5H3ou2kcOY8sQQ==}
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
       '@changesets/cli': 2.26.0
       '@types/chrome': 0.0.195
       '@types/node': 18.14.0
-      '@typescript-eslint/eslint-plugin': 5.52.0_44oiodj6oihskayaxpgdr6lwb4
-      '@typescript-eslint/parser': 5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/eslint-plugin': 5.53.0_aazihswd3uh3xo3nn2gjfpyd6q
+      '@typescript-eslint/parser': 5.53.0_4rv7y5c6xz3vfxwhbrcxxi73bq
       eslint: 8.22.0
       eslint-config-prettier: 8.6.0_eslint@8.22.0
       eslint-plugin-prettier: 4.2.1_qt54dw5ublwxu5wgrb6fweerp4
@@ -69,7 +69,7 @@ importers:
 
   packages/core/chains:
     specifiers:
-      '@wallet-standard/base': ^1.0.0
+      '@wallet-standard/base': ^1.0.1
       shx: ^0.3.4
     dependencies:
       '@wallet-standard/base': 1.0.1
@@ -78,12 +78,12 @@ importers:
 
   packages/core/features:
     specifiers:
-      '@wallet-standard/base': ^1.0.0
-      '@wallet-standard/features': ^1.0.0
+      '@wallet-standard/base': ^1.0.1
+      '@wallet-standard/features': ^1.0.3
       shx: ^0.3.4
     dependencies:
       '@wallet-standard/base': 1.0.1
-      '@wallet-standard/features': 1.0.1
+      '@wallet-standard/features': 1.0.3
     devDependencies:
       shx: 0.3.4
 
@@ -117,10 +117,10 @@ importers:
       '@solana/wallet-standard-util': workspace:^
       '@solana/web3.js': ^1.58.0
       '@types/bs58': ^4.0.1
-      '@wallet-standard/app': ^1.0.0
-      '@wallet-standard/base': ^1.0.0
-      '@wallet-standard/features': ^1.0.0
-      '@wallet-standard/wallet': ^1.0.0
+      '@wallet-standard/app': ^1.0.1
+      '@wallet-standard/base': ^1.0.1
+      '@wallet-standard/features': ^1.0.3
+      '@wallet-standard/wallet': ^1.0.1
       bs58: ^4.0.1
       shx: ^0.3.4
     dependencies:
@@ -130,7 +130,7 @@ importers:
       '@solana/wallet-standard-util': link:../../core/util
       '@wallet-standard/app': 1.0.1
       '@wallet-standard/base': 1.0.1
-      '@wallet-standard/features': 1.0.1
+      '@wallet-standard/features': 1.0.3
       '@wallet-standard/wallet': 1.0.1
     devDependencies:
       '@solana/web3.js': 1.73.2
@@ -143,8 +143,8 @@ importers:
       '@solana/wallet-adapter-base': ^0.9.21
       '@solana/wallet-standard-wallet-adapter-base': workspace:^
       '@types/react': ^18.0.23
-      '@wallet-standard/app': ^1.0.0
-      '@wallet-standard/base': ^1.0.0
+      '@wallet-standard/app': ^1.0.1
+      '@wallet-standard/base': ^1.0.1
       react: ^18.2.0
       shx: ^0.3.4
     dependencies:
@@ -163,8 +163,8 @@ importers:
       '@solana/web3.js': ^1.58.0
       '@types/bs58': ^4.0.1
       '@types/node-fetch': ^2.6.2
-      '@wallet-standard/base': ^1.0.0
-      '@wallet-standard/features': ^1.0.0
+      '@wallet-standard/base': ^1.0.1
+      '@wallet-standard/features': ^1.0.3
       bs58: ^4.0.1
       prettier: ^2.7.1
       shx: ^0.3.4
@@ -173,7 +173,7 @@ importers:
       '@solana/wallet-standard-features': link:../../core/features
       '@solana/web3.js': 1.73.2
       '@wallet-standard/base': 1.0.1
-      '@wallet-standard/features': 1.0.1
+      '@wallet-standard/features': 1.0.3
       bs58: 4.0.1
     devDependencies:
       '@types/bs58': 4.0.1
@@ -188,8 +188,8 @@ importers:
       '@solana/web3.js': ^1.58.0
       '@types/bs58': ^4.0.1
       '@types/node-fetch': ^2.6.2
-      '@wallet-standard/base': ^1.0.0
-      '@wallet-standard/features': ^1.0.0
+      '@wallet-standard/base': ^1.0.1
+      '@wallet-standard/features': ^1.0.3
       bs58: ^4.0.1
       prettier: ^2.7.1
       shx: ^0.3.4
@@ -198,7 +198,7 @@ importers:
       '@solana/wallet-standard-features': link:../../core/features
       '@solana/web3.js': 1.73.2
       '@wallet-standard/base': 1.0.1
-      '@wallet-standard/features': 1.0.1
+      '@wallet-standard/features': 1.0.3
       bs58: 4.0.1
     devDependencies:
       '@types/bs58': 4.0.1
@@ -214,8 +214,8 @@ importers:
       '@solflare-wallet/sdk': ^1.1.0
       '@types/bs58': ^4.0.1
       '@types/node-fetch': ^2.6.2
-      '@wallet-standard/base': ^1.0.0
-      '@wallet-standard/features': ^1.0.0
+      '@wallet-standard/base': ^1.0.1
+      '@wallet-standard/features': ^1.0.3
       bs58: ^4.0.1
       prettier: ^2.7.1
       shx: ^0.3.4
@@ -225,7 +225,7 @@ importers:
       '@solana/web3.js': 1.73.2
       '@solflare-wallet/sdk': 1.2.0_@solana+web3.js@1.73.2
       '@wallet-standard/base': 1.0.1
-      '@wallet-standard/features': 1.0.1
+      '@wallet-standard/features': 1.0.3
       bs58: 4.0.1
     devDependencies:
       '@types/bs58': 4.0.1
@@ -257,8 +257,8 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@babel/runtime/7.20.13:
-    resolution: {integrity: sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==}
+  /@babel/runtime/7.21.0:
+    resolution: {integrity: sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
@@ -266,7 +266,7 @@ packages:
   /@changesets/apply-release-plan/6.1.3:
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@changesets/config': 2.3.0
       '@changesets/get-version-range-type': 0.3.2
       '@changesets/git': 2.0.0
@@ -284,7 +284,7 @@ packages:
   /@changesets/assemble-release-plan/5.2.3:
     resolution: {integrity: sha512-g7EVZCmnWz3zMBAdrcKhid4hkHT+Ft1n0mLussFMcB1dE2zCuwcvGoy9ec3yOgPGF4hoMtgHaMIk3T3TBdvU9g==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@changesets/errors': 0.1.4
       '@changesets/get-dependents-graph': 1.3.5
       '@changesets/types': 5.2.1
@@ -302,7 +302,7 @@ packages:
     resolution: {integrity: sha512-0cbTiDms+ICTVtEwAFLNW0jBNex9f5+fFv3I771nBvdnV/mOjd1QJ4+f8KtVSOrwD9SJkk9xbDkWFb0oXd8d1Q==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@changesets/apply-release-plan': 6.1.3
       '@changesets/assemble-release-plan': 5.2.3
       '@changesets/changelog-git': 0.1.14
@@ -368,7 +368,7 @@ packages:
   /@changesets/get-release-plan/3.0.16:
     resolution: {integrity: sha512-OpP9QILpBp1bY2YNIKFzwigKh7Qe9KizRsZomzLe6pK8IUo8onkAAVUD8+JRKSr8R7d4+JRuQrfSSNlEwKyPYg==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@changesets/assemble-release-plan': 5.2.3
       '@changesets/config': 2.3.0
       '@changesets/pre': 1.0.14
@@ -384,7 +384,7 @@ packages:
   /@changesets/git/2.0.0:
     resolution: {integrity: sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -409,7 +409,7 @@ packages:
   /@changesets/pre/1.0.14:
     resolution: {integrity: sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -419,7 +419,7 @@ packages:
   /@changesets/read/0.5.9:
     resolution: {integrity: sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@changesets/git': 2.0.0
       '@changesets/logger': 0.0.5
       '@changesets/parse': 0.3.16
@@ -440,7 +440,7 @@ packages:
   /@changesets/write/0.2.3:
     resolution: {integrity: sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@changesets/types': 5.2.1
       fs-extra: 7.0.1
       human-id: 1.0.2
@@ -486,7 +486,7 @@ packages:
   /@manypkg/find-root/1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -495,7 +495,7 @@ packages:
   /@manypkg/get-packages/1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -559,7 +559,7 @@ packages:
       '@solana/wallet-standard-features': 1.0.0
       '@solana/web3.js': 1.73.2
       '@wallet-standard/base': 1.0.1
-      '@wallet-standard/features': 1.0.1
+      '@wallet-standard/features': 1.0.3
       eventemitter3: 4.0.7
 
   /@solana/wallet-standard-features/1.0.0:
@@ -567,13 +567,13 @@ packages:
     engines: {node: '>=16'}
     dependencies:
       '@wallet-standard/base': 1.0.1
-      '@wallet-standard/features': 1.0.1
+      '@wallet-standard/features': 1.0.3
 
   /@solana/web3.js/1.73.2:
     resolution: {integrity: sha512-9WACF8W4Nstj7xiDw3Oom22QmrhBh0VyZyZ7JvvG3gOxLWLlX3hvm5nPVJOGcCE/9fFavBbCUb5A6CIuvMGdoA==}
     engines: {node: '>=12.20.0'}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@noble/ed25519': 1.7.3
       '@noble/hashes': 1.2.0
       '@noble/secp256k1': 1.7.1
@@ -700,8 +700,8 @@ packages:
     dependencies:
       '@types/node': 12.20.55
 
-  /@typescript-eslint/eslint-plugin/5.52.0_44oiodj6oihskayaxpgdr6lwb4:
-    resolution: {integrity: sha512-lHazYdvYVsBokwCdKOppvYJKaJ4S41CgKBcPvyd0xjZNbvQdhn/pnJlGtQksQ/NhInzdaeaSarlBjDXHuclEbg==}
+  /@typescript-eslint/eslint-plugin/5.53.0_aazihswd3uh3xo3nn2gjfpyd6q:
+    resolution: {integrity: sha512-alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -711,10 +711,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq
-      '@typescript-eslint/scope-manager': 5.52.0
-      '@typescript-eslint/type-utils': 5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq
-      '@typescript-eslint/utils': 5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/parser': 5.53.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/scope-manager': 5.53.0
+      '@typescript-eslint/type-utils': 5.53.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/utils': 5.53.0_4rv7y5c6xz3vfxwhbrcxxi73bq
       debug: 4.3.4
       eslint: 8.22.0
       grapheme-splitter: 1.0.4
@@ -728,8 +728,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
-    resolution: {integrity: sha512-e2KiLQOZRo4Y0D/b+3y08i3jsekoSkOYStROYmPUnGMEoA0h+k2qOH5H6tcjIc68WDvGwH+PaOrP1XRzLJ6QlA==}
+  /@typescript-eslint/parser/5.53.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
+    resolution: {integrity: sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -738,9 +738,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.52.0
-      '@typescript-eslint/types': 5.52.0
-      '@typescript-eslint/typescript-estree': 5.52.0_typescript@4.7.4
+      '@typescript-eslint/scope-manager': 5.53.0
+      '@typescript-eslint/types': 5.53.0
+      '@typescript-eslint/typescript-estree': 5.53.0_typescript@4.7.4
       debug: 4.3.4
       eslint: 8.22.0
       typescript: 4.7.4
@@ -748,16 +748,16 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager/5.52.0:
-    resolution: {integrity: sha512-AR7sxxfBKiNV0FWBSARxM8DmNxrwgnYMPwmpkC1Pl1n+eT8/I2NAUPuwDy/FmDcC6F8pBfmOcaxcxRHspgOBMw==}
+  /@typescript-eslint/scope-manager/5.53.0:
+    resolution: {integrity: sha512-Opy3dqNsp/9kBBeCPhkCNR7fmdSQqA+47r21hr9a14Bx0xnkElEQmhoHga+VoaoQ6uDHjDKmQPIYcUcKJifS7w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.52.0
-      '@typescript-eslint/visitor-keys': 5.52.0
+      '@typescript-eslint/types': 5.53.0
+      '@typescript-eslint/visitor-keys': 5.53.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
-    resolution: {integrity: sha512-tEKuUHfDOv852QGlpPtB3lHOoig5pyFQN/cUiZtpw99D93nEBjexRLre5sQZlkMoHry/lZr8qDAt2oAHLKA6Jw==}
+  /@typescript-eslint/type-utils/5.53.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
+    resolution: {integrity: sha512-HO2hh0fmtqNLzTAme/KnND5uFNwbsdYhCZghK2SoxGp3Ifn2emv+hi0PBUjzzSh0dstUIFqOj3bp0AwQlK4OWw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -766,8 +766,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.52.0_typescript@4.7.4
-      '@typescript-eslint/utils': 5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/typescript-estree': 5.53.0_typescript@4.7.4
+      '@typescript-eslint/utils': 5.53.0_4rv7y5c6xz3vfxwhbrcxxi73bq
       debug: 4.3.4
       eslint: 8.22.0
       tsutils: 3.21.0_typescript@4.7.4
@@ -776,13 +776,13 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types/5.52.0:
-    resolution: {integrity: sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==}
+  /@typescript-eslint/types/5.53.0:
+    resolution: {integrity: sha512-5kcDL9ZUIP756K6+QOAfPkigJmCPHcLN7Zjdz76lQWWDdzfOhZDTj1irs6gPBKiXx5/6O3L0+AvupAut3z7D2A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.52.0_typescript@4.7.4:
-    resolution: {integrity: sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==}
+  /@typescript-eslint/typescript-estree/5.53.0_typescript@4.7.4:
+    resolution: {integrity: sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -790,8 +790,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.52.0
-      '@typescript-eslint/visitor-keys': 5.52.0
+      '@typescript-eslint/types': 5.53.0
+      '@typescript-eslint/visitor-keys': 5.53.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -802,17 +802,17 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.52.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
-    resolution: {integrity: sha512-As3lChhrbwWQLNk2HC8Ree96hldKIqk98EYvypd3It8Q1f8d5zWyIoaZEp2va5667M4ZyE7X8UUR+azXrFl+NA==}
+  /@typescript-eslint/utils/5.53.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
+    resolution: {integrity: sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@types/json-schema': 7.0.11
       '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.52.0
-      '@typescript-eslint/types': 5.52.0
-      '@typescript-eslint/typescript-estree': 5.52.0_typescript@4.7.4
+      '@typescript-eslint/scope-manager': 5.53.0
+      '@typescript-eslint/types': 5.53.0
+      '@typescript-eslint/typescript-estree': 5.53.0_typescript@4.7.4
       eslint: 8.22.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.22.0
@@ -822,11 +822,11 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys/5.52.0:
-    resolution: {integrity: sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==}
+  /@typescript-eslint/visitor-keys/5.53.0:
+    resolution: {integrity: sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.52.0
+      '@typescript-eslint/types': 5.53.0
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -841,8 +841,8 @@ packages:
     resolution: {integrity: sha512-1To3ekMfzhYxe0Yhkpri+Fedq0SYcfrOfJi3vbLjMwF2qiKPjTGLwZkf2C9ftdQmxES+hmxhBzTwF4KgcOwf8w==}
     engines: {node: '>=16'}
 
-  /@wallet-standard/features/1.0.1:
-    resolution: {integrity: sha512-B/WzRpoEiGQ+kwL/AuzqzNjrGvdL5J2OXiXHkDGONsNbKdtTpExU+ttZKQwSP/EvPl8+ZZ/4OO/Bz4YkigtQDg==}
+  /@wallet-standard/features/1.0.3:
+    resolution: {integrity: sha512-m8475I6W5LTatTZuUz5JJNK42wFRgkJTB0I9tkruMwfqBF2UN2eomkYNVf9RbrsROelCRzSFmugqjKZBFaubsA==}
     engines: {node: '>=16'}
     dependencies:
       '@wallet-standard/base': 1.0.1
@@ -2908,7 +2908,7 @@ packages:
   /rpc-websockets/7.5.0:
     resolution: {integrity: sha512-9tIRi1uZGy7YmDjErf1Ax3wtqdSSLIlnmL5OtOzgd5eqPKbsPpwDP5whUDO2LQay3Xp0CcHlcNSGzacNRluBaQ==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       eventemitter3: 4.0.7
       uuid: 8.3.2
       ws: 8.12.1_3cxu5zja4e2r5wmvge7mdcljwq
@@ -3240,7 +3240,7 @@ packages:
       smartwrap: 2.0.2
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
-      yargs: 17.7.0
+      yargs: 17.7.1
     dev: true
 
   /type-check/0.4.0:
@@ -3519,8 +3519,8 @@ packages:
       yargs-parser: 18.1.3
     dev: true
 
-  /yargs/17.7.0:
-    resolution: {integrity: sha512-dwqOPg5trmrre9+v8SUo2q/hAwyKoVfu8OC1xPHKJGNdxAvPl4sKxL4vBnh3bQz/ZvvGAFeA5H3ou2kcOY8sQQ==}
+  /yargs/17.7.1:
+    resolution: {integrity: sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==}
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ importers:
   packages/core/_:
     specifiers:
       '@solana/wallet-standard-chains': workspace:^
-      '@solana/wallet-standard-features': workspace:^
+      '@solana/wallet-standard-features': ^1.0.1
       '@solana/wallet-standard-util': workspace:^
       shx: ^0.3.4
     dependencies:
@@ -90,7 +90,7 @@ importers:
   packages/core/util:
     specifiers:
       '@solana/wallet-standard-chains': workspace:^
-      '@solana/wallet-standard-features': workspace:^
+      '@solana/wallet-standard-features': ^1.0.1
       shx: ^0.3.4
     dependencies:
       '@solana/wallet-standard-chains': link:../chains
@@ -113,7 +113,7 @@ importers:
     specifiers:
       '@solana/wallet-adapter-base': ^0.9.21
       '@solana/wallet-standard-chains': workspace:^
-      '@solana/wallet-standard-features': workspace:^
+      '@solana/wallet-standard-features': ^1.0.1
       '@solana/wallet-standard-util': workspace:^
       '@solana/web3.js': ^1.58.0
       '@types/bs58': ^4.0.1
@@ -159,7 +159,7 @@ importers:
 
   packages/wallets/ghost:
     specifiers:
-      '@solana/wallet-standard-features': ^1.0.0
+      '@solana/wallet-standard-features': ^1.0.1
       '@solana/web3.js': ^1.58.0
       '@types/bs58': ^4.0.1
       '@types/node-fetch': ^2.6.2
@@ -184,7 +184,7 @@ importers:
 
   packages/wallets/phantom:
     specifiers:
-      '@solana/wallet-standard-features': ^1.0.0
+      '@solana/wallet-standard-features': ^1.0.1
       '@solana/web3.js': ^1.58.0
       '@types/bs58': ^4.0.1
       '@types/node-fetch': ^2.6.2
@@ -209,7 +209,7 @@ importers:
 
   packages/wallets/solflare:
     specifiers:
-      '@solana/wallet-standard-features': ^1.0.0
+      '@solana/wallet-standard-features': ^1.0.1
       '@solana/web3.js': ^1.58.0
       '@solflare-wallet/sdk': ^1.1.0
       '@types/bs58': ^4.0.1


### PR DESCRIPTION
https://github.com/solana-labs/wallet-adapter/pull/726 moved some of the types from `@solana/wallet-standard-wallet-adapter-base` into `@solana/wallet-adapter-base`. This PR updates `@solana/wallet-standard-wallet-adapter-base` to use and re-export them.

Additionally, following https://github.com/wallet-standard/wallet-standard/pull/79, apps and wallets needing to feature detect with strings like `if ("solana:signTransaction") in wallet.features` is verbose and error prone. Exporting and using these feature names as constant strings will help.

Blocked by https://github.com/wallet-standard/wallet-standard/pull/79