### PR TITLE
Fix error issued when disconnecting wallet

### DIFF
--- a/packages/wallet-adapter/base/src/adapter.ts
+++ b/packages/wallet-adapter/base/src/adapter.ts
@@ -200,7 +200,6 @@ export class StandardWalletAdapter extends BaseWalletAdapter implements Standard
         // If there's no connected account, disconnect the adapter.
         if (!account) {
             this.#disconnected();
-            this.emit('error', new WalletDisconnectedError());
             this.emit('disconnect');
             return;
         }


### PR DESCRIPTION
Fixing the error raised when a standard wallet is disconnected. Previously mentioned here https://github.com/solana-labs/wallet-adapter/issues/742
and here https://github.com/solana-labs/wallet-adapter/issues/185