### PR TITLE
Sign In: make all fields optional

### DIFF
--- a/.changeset/brave-timers-destroy.md
+++ b/.changeset/brave-timers-destroy.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-standard-features': minor
+---
+
+Add `solana:signIn` (Sign In With Solana) feature

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -13,6 +13,7 @@
     "@solana/wallet-standard-ghost": "0.0.0"
   },
   "changesets": [
+    "brave-timers-destroy",
     "friendly-cycles-switch",
     "strong-plants-cheat"
   ]

--- a/packages/_/_/CHANGELOG.md
+++ b/packages/_/_/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @solana/wallet-standard
 
+## 1.0.3-alpha.2
+
+### Patch Changes
+
+-   @solana/wallet-standard-core@1.0.1-alpha.2
+-   @solana/wallet-standard-wallet-adapter@1.0.3-alpha.2
+
 ## 1.0.3-alpha.1
 
 ### Patch Changes

--- a/packages/_/_/package.json
+++ b/packages/_/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard",
-    "version": "1.0.3-alpha.1",
+    "version": "1.0.3-alpha.2",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/_/CHANGELOG.md
+++ b/packages/core/_/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @solana/wallet-standard-core
 
+## 1.0.1-alpha.2
+
+### Patch Changes
+
+-   Updated dependencies [4a33a30]
+    -   @solana/wallet-standard-features@1.1.0-alpha.2
+    -   @solana/wallet-standard-util@1.0.1-alpha.2
+
 ## 1.0.1-alpha.1
 
 ### Patch Changes

--- a/packages/core/_/package.json
+++ b/packages/core/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-core",
-    "version": "1.0.1-alpha.1",
+    "version": "1.0.1-alpha.2",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/features/CHANGELOG.md
+++ b/packages/core/features/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @solana/wallet-standard-features
 
+## 1.1.0-alpha.2
+
+### Minor Changes
+
+-   4a33a30: Add `solana:signIn` (Sign In With Solana) feature
+
 ## 1.1.0-alpha.1
 
 ### Minor Changes

--- a/packages/core/features/package.json
+++ b/packages/core/features/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-features",
-    "version": "1.1.0-alpha.1",
+    "version": "1.1.0-alpha.2",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/features/src/signIn.ts
+++ b/packages/core/features/src/signIn.ts
@@ -23,35 +23,38 @@ export type SolanaSignInMethod = (...inputs: readonly SolanaSignInInput[]) => Pr
 
 /** Input for signing in. */
 export interface SolanaSignInInput {
-    /** EIP-4361 Domain. */
-    readonly domain: string;
+    /**
+     * Optional EIP-4361 Domain.
+     * If not provided, the wallet must determine the Domain to use.
+     */
+    readonly domain?: string;
 
     /**
-     * Optional account to use. If not provided, the wallet must determine the account to use.
-     * Used to determine EIP-4361 Address.
+     * Optional account to use, used to determine EIP-4361 Address.
+     * If not provided, the wallet must determine the Address to use.
      */
     readonly account?: WalletAccount;
 
     /** Optional EIP-4361 Statement. */
     readonly statement?: string;
 
-    /** EIP-4361 URI. */
-    readonly uri: string;
+    /** Optional EIP-4361 URI. */
+    readonly uri?: string;
 
-    /** EIP-4361 Version. */
-    readonly version: '1';
+    /** Optional EIP-4361 Version. */
+    readonly version?: '1';
 
     /**
-     * Chain, as defined by the Wallet Standard.
+     * Optional Chain, as defined by the Wallet Standard.
      * Used instead of EIP-4361 Chain ID.
      */
-    readonly chain: IdentifierString;
+    readonly chain?: IdentifierString;
 
-    /** EIP-4361 Nonce. */
-    readonly nonce: string;
+    /** Optional EIP-4361 Nonce. */
+    readonly nonce?: string;
 
-    /** EIP-4361 Issued At. */
-    readonly issuedAt: string;
+    /** Optional EIP-4361 Issued At. */
+    readonly issuedAt?: string;
 
     /** Optional EIP-4361 Expiration Time. */
     readonly expirationTime?: string;

--- a/packages/core/util/CHANGELOG.md
+++ b/packages/core/util/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @solana/wallet-standard-util
 
+## 1.0.1-alpha.2
+
+### Patch Changes
+
+-   Updated dependencies [4a33a30]
+    -   @solana/wallet-standard-features@1.1.0-alpha.2
+
 ## 1.0.1-alpha.1
 
 ### Patch Changes

--- a/packages/core/util/package.json
+++ b/packages/core/util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-util",
-    "version": "1.0.1-alpha.1",
+    "version": "1.0.1-alpha.2",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/_/CHANGELOG.md
+++ b/packages/wallet-adapter/_/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @solana/wallet-standard-wallet-adapter
 
+## 1.0.3-alpha.2
+
+### Patch Changes
+
+-   @solana/wallet-standard-wallet-adapter-base@1.0.3-alpha.2
+-   @solana/wallet-standard-wallet-adapter-react@1.0.3-alpha.2
+
 ## 1.0.3-alpha.1
 
 ### Patch Changes

--- a/packages/wallet-adapter/_/package.json
+++ b/packages/wallet-adapter/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter",
-    "version": "1.0.3-alpha.1",
+    "version": "1.0.3-alpha.2",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/base/CHANGELOG.md
+++ b/packages/wallet-adapter/base/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @solana/wallet-standard-wallet-adapter-base
 
+## 1.0.3-alpha.2
+
+### Patch Changes
+
+-   Updated dependencies [4a33a30]
+    -   @solana/wallet-standard-features@1.1.0-alpha.2
+    -   @solana/wallet-standard-util@1.0.1-alpha.2
+
 ## 1.0.3-alpha.1
 
 ### Patch Changes

--- a/packages/wallet-adapter/base/package.json
+++ b/packages/wallet-adapter/base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter-base",
-    "version": "1.0.3-alpha.1",
+    "version": "1.0.3-alpha.2",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/react/CHANGELOG.md
+++ b/packages/wallet-adapter/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @solana/wallet-standard-wallet-adapter-react
 
+## 1.0.3-alpha.2
+
+### Patch Changes
+
+-   @solana/wallet-standard-wallet-adapter-base@1.0.3-alpha.2
+
 ## 1.0.3-alpha.1
 
 ### Patch Changes

--- a/packages/wallet-adapter/react/package.json
+++ b/packages/wallet-adapter/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter-react",
-    "version": "1.0.3-alpha.1",
+    "version": "1.0.3-alpha.2",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",


### PR DESCRIPTION
In the EIP-4361 message, Domain and Address are the only required values for authentication. Both values can be provided by the wallet if not provided by the caller. The caller may wish to reuse the same message without a nonce, URI, chain to produce a deterministic signature (for example, to generate a cryptographic key from). Wallets don't need to enforce the existence of these fields if applications don't use them.