### PR TITLE
More Sign In changes

### DIFF
--- a/.changeset/lucky-spiders-search.md
+++ b/.changeset/lucky-spiders-search.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-standard-features': minor
+---
+
+Add `solana:signIn` (Sign In With Solana) feature

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -15,6 +15,7 @@
   "changesets": [
     "brave-timers-destroy",
     "friendly-cycles-switch",
+    "lucky-spiders-search",
     "strong-plants-cheat"
   ]
 }

--- a/packages/_/_/CHANGELOG.md
+++ b/packages/_/_/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @solana/wallet-standard
 
+## 1.0.3-alpha.3
+
+### Patch Changes
+
+-   @solana/wallet-standard-core@1.0.1-alpha.3
+-   @solana/wallet-standard-wallet-adapter@1.0.3-alpha.3
+
 ## 1.0.3-alpha.2
 
 ### Patch Changes

--- a/packages/_/_/package.json
+++ b/packages/_/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard",
-    "version": "1.0.3-alpha.2",
+    "version": "1.0.3-alpha.3",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/_/CHANGELOG.md
+++ b/packages/core/_/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @solana/wallet-standard-core
 
+## 1.0.1-alpha.3
+
+### Patch Changes
+
+-   Updated dependencies [8160fe9]
+    -   @solana/wallet-standard-features@1.1.0-alpha.3
+    -   @solana/wallet-standard-util@1.0.1-alpha.3
+
 ## 1.0.1-alpha.2
 
 ### Patch Changes

--- a/packages/core/_/package.json
+++ b/packages/core/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-core",
-    "version": "1.0.1-alpha.2",
+    "version": "1.0.1-alpha.3",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/features/CHANGELOG.md
+++ b/packages/core/features/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @solana/wallet-standard-features
 
+## 1.1.0-alpha.3
+
+### Minor Changes
+
+-   8160fe9: Add `solana:signIn` (Sign In With Solana) feature
+
 ## 1.1.0-alpha.2
 
 ### Minor Changes

--- a/packages/core/features/package.json
+++ b/packages/core/features/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-features",
-    "version": "1.1.0-alpha.2",
+    "version": "1.1.0-alpha.3",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/features/src/signIn.ts
+++ b/packages/core/features/src/signIn.ts
@@ -42,7 +42,7 @@ export interface SolanaSignInInput {
     readonly uri?: string;
 
     /** Optional EIP-4361 Version. */
-    readonly version?: '1';
+    readonly version?: string;
 
     /**
      * Optional Chain, as defined by the Wallet Standard.

--- a/packages/core/features/src/signIn.ts
+++ b/packages/core/features/src/signIn.ts
@@ -98,15 +98,27 @@ export interface SolanaSignInInput {
 
 /** Output of signing in. */
 export interface SolanaSignInOutput {
-    /** TODO: docs */
+    /**
+     * Account that was signed in.
+     * The address of the account may be different from the provided input Address.
+     */
     readonly account: WalletAccount;
 
-    /** TODO: docs */
+    /**
+     * Message bytes that were signed.
+     * The wallet may prefix or otherwise modify the message before signing it.
+     */
     readonly signedMessage: Uint8Array;
 
-    /** TODO: docs */
+    /**
+     * Message signature produced.
+     * If the signature type is provided, the signature must be Ed25519.
+     */
     readonly signature: Uint8Array;
 
-    /** TODO: docs */
-    readonly signatureType?: string;
+    /**
+     * Optional type of the message signature produced.
+     * If not provided, the signature must be Ed25519.
+     */
+    readonly signatureType?: 'ed25519';
 }

--- a/packages/core/features/src/signIn.ts
+++ b/packages/core/features/src/signIn.ts
@@ -48,7 +48,7 @@ export interface SolanaSignInInput {
      * Optional Chain, as defined by the Wallet Standard.
      * Used instead of EIP-4361 Chain ID.
      */
-    readonly chain?: IdentifierString;
+    readonly chainId?: string;
 
     /** Optional EIP-4361 Nonce. */
     readonly nonce?: string;

--- a/packages/core/features/src/signIn.ts
+++ b/packages/core/features/src/signIn.ts
@@ -33,7 +33,7 @@ export interface SolanaSignInInput {
      * Optional account to use, used to determine EIP-4361 Address.
      * If not provided, the wallet must determine the Address to use.
      */
-    readonly account?: WalletAccount;
+    readonly address?: string;
 
     /** Optional EIP-4361 Statement. */
     readonly statement?: string;

--- a/packages/core/features/src/signIn.ts
+++ b/packages/core/features/src/signIn.ts
@@ -25,47 +25,74 @@ export type SolanaSignInMethod = (...inputs: readonly SolanaSignInInput[]) => Pr
 export interface SolanaSignInInput {
     /**
      * Optional EIP-4361 Domain.
-     * If not provided, the wallet must determine the Domain to use.
+     * If not provided, the wallet must determine the Domain to include in the message.
      */
     readonly domain?: string;
 
     /**
-     * Optional account to use, used to determine EIP-4361 Address.
-     * If not provided, the wallet must determine the Address to use.
+     * Optional EIP-4361 Address.
+     * If not provided, the wallet must determine the Address to include in the message.
      */
     readonly address?: string;
 
-    /** Optional EIP-4361 Statement. */
+    /**
+     * Optional EIP-4361 Statement.
+     * If not provided, the wallet must not include Statement in the message.
+     */
     readonly statement?: string;
 
-    /** Optional EIP-4361 URI. */
+    /**
+     * Optional EIP-4361 URI.
+     * If not provided, the wallet must not include URI in the message.
+     */
     readonly uri?: string;
 
-    /** Optional EIP-4361 Version. */
+    /**
+     * Optional EIP-4361 Version.
+     * If not provided, the wallet must not include Version in the message.
+     */
     readonly version?: string;
 
     /**
-     * Optional Chain, as defined by the Wallet Standard.
-     * Used instead of EIP-4361 Chain ID.
+     * Optional EIP-4361 Chain ID.
+     * If not provided, the wallet must not include Chain ID in the message.
      */
     readonly chainId?: string;
 
-    /** Optional EIP-4361 Nonce. */
+    /**
+     * Optional EIP-4361 Nonce.
+     * If not provided, the wallet must not include Nonce in the message.
+     */
     readonly nonce?: string;
 
-    /** Optional EIP-4361 Issued At. */
+    /**
+     * Optional EIP-4361 Issued At.
+     * If not provided, the wallet must not include Issued At in the message.
+     */
     readonly issuedAt?: string;
 
-    /** Optional EIP-4361 Expiration Time. */
+    /**
+     * Optional EIP-4361 Expiration Time.
+     * If not provided, the wallet must not include Expiration Time in the message.
+     */
     readonly expirationTime?: string;
 
-    /** Optional EIP-4361 Not Before. */
+    /**
+     * Optional EIP-4361 Not Before.
+     * If not provided, the wallet must not include Not Before in the message.
+     */
     readonly notBefore?: string;
 
-    /** Optional EIP-4361 Request ID. */
+    /**
+     * Optional EIP-4361 Request ID.
+     * If not provided, the wallet must not include Request ID in the message.
+     */
     readonly requestId?: string;
 
-    /** Optional EIP-4361 Resources. */
+    /**
+     * Optional EIP-4361 Resources.
+     * If not provided, the wallet must not include Resources in the message.
+     */
     readonly resources?: readonly string[];
 }
 

--- a/packages/core/features/src/signMessage.ts
+++ b/packages/core/features/src/signMessage.ts
@@ -34,12 +34,21 @@ export interface SolanaSignMessageInput {
 
 /** Output of signing a message. */
 export interface SolanaSignMessageOutput {
-    /** TODO: docs */
+    /**
+     * Message bytes that were signed.
+     * The wallet may prefix or otherwise modify the message before signing it.
+     */
     readonly signedMessage: Uint8Array;
 
-    /** TODO: docs */
+    /**
+     * Message signature produced.
+     * If the signature type is provided, the signature must be Ed25519.
+     */
     readonly signature: Uint8Array;
 
-    /** TODO: docs */
-    readonly signatureType?: string;
+    /**
+     * Optional type of the message signature produced.
+     * If not provided, the signature must be Ed25519.
+     */
+    readonly signatureType?: 'ed25519';
 }

--- a/packages/core/util/CHANGELOG.md
+++ b/packages/core/util/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @solana/wallet-standard-util
 
+## 1.0.1-alpha.3
+
+### Patch Changes
+
+-   Updated dependencies [8160fe9]
+    -   @solana/wallet-standard-features@1.1.0-alpha.3
+
 ## 1.0.1-alpha.2
 
 ### Patch Changes

--- a/packages/core/util/package.json
+++ b/packages/core/util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-util",
-    "version": "1.0.1-alpha.2",
+    "version": "1.0.1-alpha.3",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/_/CHANGELOG.md
+++ b/packages/wallet-adapter/_/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @solana/wallet-standard-wallet-adapter
 
+## 1.0.3-alpha.3
+
+### Patch Changes
+
+-   @solana/wallet-standard-wallet-adapter-base@1.0.3-alpha.3
+-   @solana/wallet-standard-wallet-adapter-react@1.0.3-alpha.3
+
 ## 1.0.3-alpha.2
 
 ### Patch Changes

--- a/packages/wallet-adapter/_/package.json
+++ b/packages/wallet-adapter/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter",
-    "version": "1.0.3-alpha.2",
+    "version": "1.0.3-alpha.3",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/base/CHANGELOG.md
+++ b/packages/wallet-adapter/base/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @solana/wallet-standard-wallet-adapter-base
 
+## 1.0.3-alpha.3
+
+### Patch Changes
+
+-   Updated dependencies [8160fe9]
+    -   @solana/wallet-standard-features@1.1.0-alpha.3
+    -   @solana/wallet-standard-util@1.0.1-alpha.3
+
 ## 1.0.3-alpha.2
 
 ### Patch Changes

--- a/packages/wallet-adapter/base/package.json
+++ b/packages/wallet-adapter/base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter-base",
-    "version": "1.0.3-alpha.2",
+    "version": "1.0.3-alpha.3",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/react/CHANGELOG.md
+++ b/packages/wallet-adapter/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @solana/wallet-standard-wallet-adapter-react
 
+## 1.0.3-alpha.3
+
+### Patch Changes
+
+-   @solana/wallet-standard-wallet-adapter-base@1.0.3-alpha.3
+
 ## 1.0.3-alpha.2
 
 ### Patch Changes

--- a/packages/wallet-adapter/react/package.json
+++ b/packages/wallet-adapter/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter-react",
-    "version": "1.0.3-alpha.2",
+    "version": "1.0.3-alpha.3",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",


### PR DESCRIPTION
This PR targets the `alpha` branch.

- Input `account` is now `address`. The app cannot be expected to have a reference to, or be able to construct, a `WalletAccount` object before connecting to the wallet. The account's address is already expected to uniquely identify the account. This also brings the field name inline with EIP-4361.
- Input `chain` is now `chainId`. The type is loosened to `string`. The wallet should not care what this value is, as it only concerns the application and sign in messages generally should not be used by on chain programs to secure access to resources. This also brings the field name inline with EIP-4361.
- Input `version` has been loosened to `string`. The wallet should not care what this value is, there's only `1` version in EIP-4361, and we'd need to update the spec for the feature if the fields changed.
- Output `signatureType` has been tightened to `ed25519`. Wallets and apps will need to understand the same signature types, and only one is supported for now. The minor feature version should change if we support more signature types.
- Doc comments added.