### PR TITLE
More Sign In changes

### DIFF
--- a/.changeset/popular-lions-yell.md
+++ b/.changeset/popular-lions-yell.md
@@ -1,0 +1,12 @@
+---
+'@solana/wallet-standard-wallet-adapter-react': minor
+'@solana/wallet-standard-wallet-adapter-base': minor
+'@solana/wallet-standard-wallet-adapter': minor
+'@solana/wallet-standard-features': minor
+'@solana/wallet-standard-ghost': minor
+'@solana/wallet-standard-util': minor
+'@solana/wallet-standard-core': minor
+'@solana/wallet-standard': minor
+---
+
+Add `solana:signIn` (Sign In With Solana) feature

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -17,6 +17,7 @@
     "friendly-cycles-switch",
     "lucky-spiders-search",
     "new-mice-exercise",
+    "popular-lions-yell",
     "smart-baboons-obey",
     "strong-plants-cheat",
     "wild-donkeys-argue",

--- a/packages/_/_/CHANGELOG.md
+++ b/packages/_/_/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @solana/wallet-standard
 
+## 1.1.0-alpha.8
+
+### Minor Changes
+
+-   Add `solana:signIn` (Sign In With Solana) feature
+
+### Patch Changes
+
+-   Updated dependencies
+    -   @solana/wallet-standard-wallet-adapter@1.1.0-alpha.8
+    -   @solana/wallet-standard-core@1.1.0-alpha.8
+
 ## 1.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/_/_/package.json
+++ b/packages/_/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard",
-    "version": "1.1.0-alpha.7",
+    "version": "1.1.0-alpha.8",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/_/CHANGELOG.md
+++ b/packages/core/_/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @solana/wallet-standard-core
 
+## 1.1.0-alpha.8
+
+### Minor Changes
+
+-   Add `solana:signIn` (Sign In With Solana) feature
+
+### Patch Changes
+
+-   Updated dependencies
+    -   @solana/wallet-standard-features@1.1.0-alpha.5
+    -   @solana/wallet-standard-util@1.1.0-alpha.8
+
 ## 1.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/core/_/package.json
+++ b/packages/core/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-core",
-    "version": "1.1.0-alpha.7",
+    "version": "1.1.0-alpha.8",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/features/CHANGELOG.md
+++ b/packages/core/features/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @solana/wallet-standard-features
 
+## 1.1.0-alpha.5
+
+### Minor Changes
+
+-   Add `solana:signIn` (Sign In With Solana) feature
+
 ## 1.1.0-alpha.4
 
 ### Minor Changes

--- a/packages/core/features/package.json
+++ b/packages/core/features/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-features",
-    "version": "1.1.0-alpha.4",
+    "version": "1.1.0-alpha.5",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/util/CHANGELOG.md
+++ b/packages/core/util/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @solana/wallet-standard-util
 
+## 1.1.0-alpha.8
+
+### Minor Changes
+
+-   Add `solana:signIn` (Sign In With Solana) feature
+
+### Patch Changes
+
+-   Updated dependencies
+    -   @solana/wallet-standard-features@1.1.0-alpha.5
+
 ## 1.1.0-alpha.7
 
 ### Minor Changes

--- a/packages/core/util/package.json
+++ b/packages/core/util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-util",
-    "version": "1.1.0-alpha.7",
+    "version": "1.1.0-alpha.8",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/_/CHANGELOG.md
+++ b/packages/wallet-adapter/_/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @solana/wallet-standard-wallet-adapter
 
+## 1.1.0-alpha.8
+
+### Minor Changes
+
+-   Add `solana:signIn` (Sign In With Solana) feature
+
+### Patch Changes
+
+-   Updated dependencies
+    -   @solana/wallet-standard-wallet-adapter-react@1.1.0-alpha.8
+    -   @solana/wallet-standard-wallet-adapter-base@1.1.0-alpha.8
+
 ## 1.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/wallet-adapter/_/package.json
+++ b/packages/wallet-adapter/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter",
-    "version": "1.1.0-alpha.7",
+    "version": "1.1.0-alpha.8",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/base/CHANGELOG.md
+++ b/packages/wallet-adapter/base/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @solana/wallet-standard-wallet-adapter-base
 
+## 1.1.0-alpha.8
+
+### Minor Changes
+
+-   Add `solana:signIn` (Sign In With Solana) feature
+
+### Patch Changes
+
+-   Updated dependencies
+    -   @solana/wallet-standard-features@1.1.0-alpha.5
+    -   @solana/wallet-standard-util@1.1.0-alpha.8
+
 ## 1.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/wallet-adapter/base/package.json
+++ b/packages/wallet-adapter/base/package.json
@@ -34,7 +34,7 @@
         "bs58": "^4.0.1"
     },
     "dependencies": {
-        "@solana/wallet-adapter-base": "^0.9.21",
+        "@solana/wallet-adapter-base": "^0.9.23-alpha.1",
         "@solana/wallet-standard-chains": "workspace:^",
         "@solana/wallet-standard-features": "workspace:^",
         "@solana/wallet-standard-util": "workspace:^",

--- a/packages/wallet-adapter/base/package.json
+++ b/packages/wallet-adapter/base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter-base",
-    "version": "1.1.0-alpha.7",
+    "version": "1.1.0-alpha.8",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/react/CHANGELOG.md
+++ b/packages/wallet-adapter/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @solana/wallet-standard-wallet-adapter-react
 
+## 1.1.0-alpha.8
+
+### Minor Changes
+
+-   Add `solana:signIn` (Sign In With Solana) feature
+
+### Patch Changes
+
+-   Updated dependencies
+    -   @solana/wallet-standard-wallet-adapter-base@1.1.0-alpha.8
+
 ## 1.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/wallet-adapter/react/package.json
+++ b/packages/wallet-adapter/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter-react",
-    "version": "1.1.0-alpha.7",
+    "version": "1.1.0-alpha.8",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallets/ghost/CHANGELOG.md
+++ b/packages/wallets/ghost/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @solana/wallet-standard-ghost
 
+## 0.1.0-alpha.2
+
+### Minor Changes
+
+-   Add `solana:signIn` (Sign In With Solana) feature
+
+### Patch Changes
+
+-   Updated dependencies
+    -   @solana/wallet-standard-features@1.1.0-alpha.5
+
 ## 0.1.0-alpha.1
 
 ### Minor Changes

--- a/packages/wallets/ghost/package.json
+++ b/packages/wallets/ghost/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@solana/wallet-standard-ghost",
-    "version": "0.1.0-alpha.1",
+    "version": "0.1.0-alpha.2",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",
@@ -26,7 +26,7 @@
         "build": "npm run clean && npm run tsc && npm run package"
     },
     "dependencies": {
-        "@solana/wallet-standard-features": "^1.1.0-alpha.4",
+        "@solana/wallet-standard-features": "^1.1.0-alpha.5",
         "@solana/web3.js": "^1.58.0",
         "@wallet-standard/base": "^1.0.1",
         "@wallet-standard/features": "^1.0.3",

--- a/packages/wallets/ghost/src/wallet.ts
+++ b/packages/wallets/ghost/src/wallet.ts
@@ -3,6 +3,10 @@ import {
     type SolanaSignAndSendTransactionFeature,
     type SolanaSignAndSendTransactionMethod,
     type SolanaSignAndSendTransactionOutput,
+    SolanaSignIn,
+    type SolanaSignInFeature,
+    type SolanaSignInMethod,
+    type SolanaSignInOutput,
     SolanaSignMessage,
     type SolanaSignMessageFeature,
     type SolanaSignMessageMethod,
@@ -73,6 +77,7 @@ export class GhostWallet implements Wallet {
         SolanaSignAndSendTransactionFeature &
         SolanaSignTransactionFeature &
         SolanaSignMessageFeature &
+        SolanaSignInFeature &
         GhostFeature {
         return {
             [StandardConnect]: {
@@ -100,6 +105,10 @@ export class GhostWallet implements Wallet {
             [SolanaSignMessage]: {
                 version: '1.0.0',
                 signMessage: this.#signMessage,
+            },
+            [SolanaSignIn]: {
+                version: '1.0.0',
+                signIn: this.#signIn,
             },
             [GhostNamespace]: {
                 ghost: this.#ghost,
@@ -271,6 +280,20 @@ export class GhostWallet implements Wallet {
             for (const input of inputs) {
                 outputs.push(...(await this.#signMessage(input)));
             }
+        }
+
+        return outputs;
+    };
+
+    #signIn: SolanaSignInMethod = async (...inputs) => {
+        const outputs: SolanaSignInOutput[] = [];
+
+        if (inputs.length > 1) {
+            for (const input of inputs) {
+                outputs.push(await this.#ghost.signIn(input));
+            }
+        } else {
+            return [await this.#ghost.signIn(inputs[0])];
         }
 
         return outputs;

--- a/packages/wallets/ghost/src/window.ts
+++ b/packages/wallets/ghost/src/window.ts
@@ -1,3 +1,4 @@
+import { type SolanaSignInInput, type SolanaSignInOutput } from '@solana/wallet-standard-features';
 import type { PublicKey, SendOptions, Transaction, TransactionSignature, VersionedTransaction } from '@solana/web3.js';
 
 export interface GhostEvent {
@@ -22,4 +23,5 @@ export interface Ghost extends GhostEventEmitter {
     signTransaction<T extends Transaction | VersionedTransaction>(transaction: T): Promise<T>;
     signAllTransactions<T extends Transaction | VersionedTransaction>(transactions: T[]): Promise<T[]>;
     signMessage(message: Uint8Array): Promise<{ signature: Uint8Array }>;
+    signIn(input?: SolanaSignInInput): Promise<SolanaSignInOutput>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,7 @@ importers:
 
   packages/wallet-adapter/base:
     specifiers:
-      '@solana/wallet-adapter-base': ^0.9.21
+      '@solana/wallet-adapter-base': ^0.9.23-alpha.1
       '@solana/wallet-standard-chains': workspace:^
       '@solana/wallet-standard-features': workspace:^
       '@solana/wallet-standard-util': workspace:^
@@ -126,7 +126,7 @@ importers:
       bs58: ^4.0.1
       shx: ^0.3.4
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.21_@solana+web3.js@1.73.2
+      '@solana/wallet-adapter-base': 0.9.23-alpha.1_@solana+web3.js@1.73.2
       '@solana/wallet-standard-chains': link:../../core/chains
       '@solana/wallet-standard-features': link:../../core/features
       '@solana/wallet-standard-util': link:../../core/util
@@ -511,6 +511,20 @@ packages:
       '@wallet-standard/base': 1.0.1
       '@wallet-standard/features': 1.0.3
       eventemitter3: 4.0.7
+    dev: true
+
+  /@solana/wallet-adapter-base/0.9.23-alpha.1_@solana+web3.js@1.73.2:
+    resolution: {integrity: sha512-YgVyP4DDothcZPpQdulMMAD9O9dBDdQ5gxWrpbwmEXVefrB3gndvMVEdu4mfSwMr9JqSdks6K2qqZ5zcmpMrEw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.77.3
+    dependencies:
+      '@solana/wallet-standard-features': 1.1.0-alpha.4
+      '@solana/web3.js': 1.73.2
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.3
+      eventemitter3: 4.0.7
+    dev: false
 
   /@solana/wallet-standard-features/1.0.1:
     resolution: {integrity: sha512-SUfx7KtBJ55XIj0qAhhVcC1I6MklAXqWFEz9hDHW+6YcJIyvfix/EilBhaBik1FJ2JT0zukpOfFv8zpuAbFRbw==}
@@ -518,6 +532,15 @@ packages:
     dependencies:
       '@wallet-standard/base': 1.0.1
       '@wallet-standard/features': 1.0.3
+    dev: true
+
+  /@solana/wallet-standard-features/1.1.0-alpha.4:
+    resolution: {integrity: sha512-+jrrcAx9Of6dGlZfN083bubcGr7/IkkJxoZqAYAuXkBXr84aPJQC0CMGAZZJkGU/ZXdhCHue/8U3i/6gKXGPrg==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.3
+    dev: false
 
   /@solana/web3.js/1.73.2:
     resolution: {integrity: sha512-9WACF8W4Nstj7xiDw3Oom22QmrhBh0VyZyZ7JvvG3gOxLWLlX3hvm5nPVJOGcCE/9fFavBbCUb5A6CIuvMGdoA==}


### PR DESCRIPTION
This PR targets the alpha branch.

- Use alpha release of @solana/wallet-adapter-base.
- Add `signIn` method to `StandardWalletAdapter`.
- Add `solana:signIn` feature to `GhostWallet`.