### PR TITLE
More Sign In changes

### DIFF
--- a/.changeset/curvy-gorillas-ring.md
+++ b/.changeset/curvy-gorillas-ring.md
@@ -1,0 +1,7 @@
+---
+'@solana/wallet-standard-wallet-adapter-react': minor
+'@solana/wallet-standard-wallet-adapter-base': minor
+'@solana/wallet-standard-util': minor
+---
+
+Add `solana:signIn` (Sign In With Solana) feature

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -14,6 +14,7 @@
   },
   "changesets": [
     "brave-timers-destroy",
+    "curvy-gorillas-ring",
     "friendly-cycles-switch",
     "lucky-spiders-search",
     "new-mice-exercise",

--- a/packages/_/_/CHANGELOG.md
+++ b/packages/_/_/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @solana/wallet-standard
 
+## 1.1.0-alpha.9
+
+### Patch Changes
+
+-   @solana/wallet-standard-wallet-adapter@1.1.0-alpha.9
+-   @solana/wallet-standard-core@1.1.0-alpha.9
+
 ## 1.1.0-alpha.8
 
 ### Minor Changes

--- a/packages/_/_/package.json
+++ b/packages/_/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard",
-    "version": "1.1.0-alpha.8",
+    "version": "1.1.0-alpha.9",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/_/CHANGELOG.md
+++ b/packages/core/_/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @solana/wallet-standard-core
 
+## 1.1.0-alpha.9
+
+### Patch Changes
+
+-   Updated dependencies [dd55b62]
+    -   @solana/wallet-standard-util@1.1.0-alpha.9
+
 ## 1.1.0-alpha.8
 
 ### Minor Changes

--- a/packages/core/_/package.json
+++ b/packages/core/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-core",
-    "version": "1.1.0-alpha.8",
+    "version": "1.1.0-alpha.9",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/features/src/signIn.ts
+++ b/packages/core/features/src/signIn.ts
@@ -1,4 +1,4 @@
-import type { IdentifierString, WalletAccount } from '@wallet-standard/base';
+import type { WalletAccount } from '@wallet-standard/base';
 
 /** Name of the feature. */
 export const SolanaSignIn = 'solana:signIn';

--- a/packages/core/util/CHANGELOG.md
+++ b/packages/core/util/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @solana/wallet-standard-util
 
+## 1.1.0-alpha.9
+
+### Minor Changes
+
+-   dd55b62: Add `solana:signIn` (Sign In With Solana) feature
+
 ## 1.1.0-alpha.8
 
 ### Minor Changes

--- a/packages/core/util/package.json
+++ b/packages/core/util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-util",
-    "version": "1.1.0-alpha.8",
+    "version": "1.1.0-alpha.9",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/util/src/endpoint.ts
+++ b/packages/core/util/src/endpoint.ts
@@ -6,11 +6,18 @@ import {
     SOLANA_TESTNET_CHAIN,
 } from '@solana/wallet-standard-chains';
 
+/** TODO: docs */
 export const MAINNET_ENDPOINT = 'https://api.mainnet-beta.solana.com';
+/** TODO: docs */
 export const DEVNET_ENDPOINT = 'https://api.devnet.solana.com';
+/** TODO: docs */
 export const TESTNET_ENDPOINT = 'https://api.testnet.solana.com';
+/** TODO: docs */
 export const LOCALNET_ENDPOINT = 'http://localhost:8899';
 
+/**
+ * TODO: docs
+ */
 export function getChainForEndpoint(endpoint: string): SolanaChain {
     if (endpoint.includes(MAINNET_ENDPOINT)) return SOLANA_MAINNET_CHAIN;
     if (/\bdevnet\b/i.test(endpoint)) return SOLANA_DEVNET_CHAIN;
@@ -19,6 +26,9 @@ export function getChainForEndpoint(endpoint: string): SolanaChain {
     return SOLANA_MAINNET_CHAIN;
 }
 
+/**
+ * TODO: docs
+ */
 export function getEndpointForChain(chain: SolanaChain, endpoint?: string): string {
     if (endpoint) return endpoint;
     if (chain === SOLANA_MAINNET_CHAIN) return MAINNET_ENDPOINT;

--- a/packages/core/util/src/verify.ts
+++ b/packages/core/util/src/verify.ts
@@ -1,11 +1,14 @@
+import { ed25519 } from '@noble/curves/ed25519';
 import type {
     SolanaSignInInput,
     SolanaSignInOutput,
     SolanaSignMessageInput,
     SolanaSignMessageOutput,
 } from '@solana/wallet-standard-features';
-import { ed25519 } from '@noble/curves/ed25519';
 
+/**
+ * TODO: docs
+ */
 export function verifyMessageSignature({
     message,
     signedMessage,
@@ -21,6 +24,9 @@ export function verifyMessageSignature({
     return bytesEqual(message, signedMessage) && ed25519.verify(signature, signedMessage, publicKey);
 }
 
+/**
+ * TODO: docs
+ */
 export function verifySignMessage(input: SolanaSignMessageInput, output: SolanaSignMessageOutput): boolean {
     const {
         message,
@@ -30,6 +36,9 @@ export function verifySignMessage(input: SolanaSignMessageInput, output: SolanaS
     return verifyMessageSignature({ message, signedMessage, signature, publicKey });
 }
 
+/**
+ * TODO: docs
+ */
 export function verifySignIn(input: SolanaSignInInput, output: SolanaSignInOutput): boolean {
     const {
         signedMessage,
@@ -40,12 +49,18 @@ export function verifySignIn(input: SolanaSignInInput, output: SolanaSignInOutpu
     return !!message && verifyMessageSignature({ message, signedMessage, signature, publicKey });
 }
 
+/**
+ * TODO: docs
+ */
 export function deriveSignInMessage(input: SolanaSignInInput, output: SolanaSignInOutput): Uint8Array | null {
     const text = deriveSignInMessageText(input, output);
     if (!text) return null;
     return new TextEncoder().encode(text);
 }
 
+/**
+ * TODO: docs
+ */
 export function deriveSignInMessageText(input: SolanaSignInInput, output: SolanaSignInOutput): string | null {
     const parsed = parseSignInMessage(output.signedMessage);
     if (!parsed) return null;
@@ -70,9 +85,15 @@ export function deriveSignInMessageText(input: SolanaSignInInput, output: Solana
     return createSignInMessageText(parsed);
 }
 
+/**
+ * TODO: docs
+ */
 export type SolanaSignInInputWithRequiredFields = SolanaSignInInput &
     Required<Pick<SolanaSignInInput, 'domain' | 'address'>>;
 
+/**
+ * TODO: docs
+ */
 export function parseSignInMessage(message: Uint8Array): SolanaSignInInputWithRequiredFields | null {
     const text = new TextDecoder().decode(message);
     return parseSignInMessageText(text);
@@ -95,6 +116,9 @@ const MESSAGE = new RegExp(
     `^${DOMAIN}${ADDRESS}${STATEMENT}${URI}${VERSION}${CHAIN_ID}${NONCE}${ISSUED_AT}${EXPIRATION_TIME}${NOT_BEFORE}${REQUEST_ID}${RESOURCES}$`
 );
 
+/**
+ * TODO: docs
+ */
 export function parseSignInMessageText(text: string): SolanaSignInInputWithRequiredFields | null {
     const match = MESSAGE.exec(text);
     if (!match) return null;
@@ -119,11 +143,17 @@ export function parseSignInMessageText(text: string): SolanaSignInInputWithRequi
     };
 }
 
+/**
+ * TODO: docs
+ */
 export function createSignInMessage(input: SolanaSignInInputWithRequiredFields): Uint8Array {
     const text = createSignInMessageText(input);
     return new TextEncoder().encode(text);
 }
 
+/**
+ * TODO: docs
+ */
 export function createSignInMessageText(input: SolanaSignInInputWithRequiredFields): string {
     // ${domain} wants you to sign in with your Solana account:
     // ${address}

--- a/packages/wallet-adapter/_/CHANGELOG.md
+++ b/packages/wallet-adapter/_/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @solana/wallet-standard-wallet-adapter
 
+## 1.1.0-alpha.9
+
+### Patch Changes
+
+-   Updated dependencies [dd55b62]
+    -   @solana/wallet-standard-wallet-adapter-react@1.1.0-alpha.9
+    -   @solana/wallet-standard-wallet-adapter-base@1.1.0-alpha.9
+
 ## 1.1.0-alpha.8
 
 ### Minor Changes

--- a/packages/wallet-adapter/_/package.json
+++ b/packages/wallet-adapter/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter",
-    "version": "1.1.0-alpha.8",
+    "version": "1.1.0-alpha.9",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/base/CHANGELOG.md
+++ b/packages/wallet-adapter/base/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @solana/wallet-standard-wallet-adapter-base
 
+## 1.1.0-alpha.9
+
+### Minor Changes
+
+-   dd55b62: Add `solana:signIn` (Sign In With Solana) feature
+
+### Patch Changes
+
+-   Updated dependencies [dd55b62]
+    -   @solana/wallet-standard-util@1.1.0-alpha.9
+
 ## 1.1.0-alpha.8
 
 ### Minor Changes

--- a/packages/wallet-adapter/base/package.json
+++ b/packages/wallet-adapter/base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter-base",
-    "version": "1.1.0-alpha.8",
+    "version": "1.1.0-alpha.9",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/react/CHANGELOG.md
+++ b/packages/wallet-adapter/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @solana/wallet-standard-wallet-adapter-react
 
+## 1.1.0-alpha.9
+
+### Minor Changes
+
+-   dd55b62: Add `solana:signIn` (Sign In With Solana) feature
+
+### Patch Changes
+
+-   Updated dependencies [dd55b62]
+    -   @solana/wallet-standard-wallet-adapter-base@1.1.0-alpha.9
+
 ## 1.1.0-alpha.8
 
 ### Minor Changes

--- a/packages/wallet-adapter/react/package.json
+++ b/packages/wallet-adapter/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter-react",
-    "version": "1.1.0-alpha.8",
+    "version": "1.1.0-alpha.9",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",


### PR DESCRIPTION
This PR targets the alpha branch.

- Move the `on` event listener in `StandardWalletAdapter` to the constructor. This is needed to listen for feature changes related to the `solana:signIn` feature.
- Add a `destroy` destructor function to call the `off` function. This is needed to avoid a memory leak from moving the `on` call to the constructor.
- Refactor `StandardWalletAdapter` related to the above changes.
- Refactor the `useStandardWalletAdapters` hook to call the `destroy` function appropriately.
- Minor other cleanup.