### PR TITLE
Add `waitForCommitmentToSendNextTransaction` to `SolanaSignAndSendTransactionOptions`

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,18 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@solana/wallet-standard": "1.1.1",
+    "@solana/wallet-standard-core": "1.1.0",
+    "@solana/wallet-standard-chains": "1.1.0",
+    "@solana/wallet-standard-features": "1.1.0",
+    "@solana/wallet-standard-util": "1.1.0",
+    "@solana/wallet-standard-wallet-adapter": "1.1.1",
+    "@solana/wallet-standard-wallet-adapter-base": "1.1.1",
+    "@solana/wallet-standard-wallet-adapter-react": "1.1.1",
+    "@solana/wallet-standard-ghost": "0.1.0"
+  },
+  "changesets": [
+    "red-islands-smash"
+  ]
+}

--- a/.changeset/red-islands-smash.md
+++ b/.changeset/red-islands-smash.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-standard-features': minor
+---
+
+Add `waitForCommitmentToSendNextTransaction` to `SolanaSignAndSendTransactionOptions`

--- a/packages/_/_/CHANGELOG.md
+++ b/packages/_/_/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @solana/wallet-standard
 
+## 1.1.2-alpha.0
+
+### Patch Changes
+
+-   @solana/wallet-standard-core@1.1.1-alpha.0
+-   @solana/wallet-standard-wallet-adapter@1.1.2-alpha.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/_/_/package.json
+++ b/packages/_/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard",
-    "version": "1.1.1",
+    "version": "1.1.2-alpha.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/_/CHANGELOG.md
+++ b/packages/core/_/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @solana/wallet-standard-core
 
+## 1.1.1-alpha.0
+
+### Patch Changes
+
+-   Updated dependencies
+    -   @solana/wallet-standard-features@1.2.0-alpha.0
+    -   @solana/wallet-standard-util@1.1.1-alpha.0
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/core/_/package.json
+++ b/packages/core/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-core",
-    "version": "1.1.0",
+    "version": "1.1.1-alpha.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/features/CHANGELOG.md
+++ b/packages/core/features/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @solana/wallet-standard-features
 
+## 1.2.0-alpha.0
+
+### Minor Changes
+
+-   Add `waitForCommitmentToSendNextTransaction` to `SolanaSignAndSendTransactionOptions`
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/core/features/package.json
+++ b/packages/core/features/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-features",
-    "version": "1.1.0",
+    "version": "1.2.0-alpha.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/features/src/signAndSendTransaction.ts
+++ b/packages/core/features/src/signAndSendTransaction.ts
@@ -63,4 +63,7 @@ export type SolanaSignAndSendTransactionOptions = SolanaSignTransactionOptions &
 
     /** Maximum number of times for the RPC node to retry sending the transaction to the leader. */
     readonly maxRetries?: number;
+
+    /** Wait till specified commitment before sending the next transaction. If commitment not specified, wait till "confirmed" commitment*/
+    readonly waitForCommitmentToSendNextTransaction?: boolean;
 };

--- a/packages/core/util/CHANGELOG.md
+++ b/packages/core/util/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @solana/wallet-standard-util
 
+## 1.1.1-alpha.0
+
+### Patch Changes
+
+-   Updated dependencies
+    -   @solana/wallet-standard-features@1.2.0-alpha.0
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/core/util/package.json
+++ b/packages/core/util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-util",
-    "version": "1.1.0",
+    "version": "1.1.1-alpha.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/_/CHANGELOG.md
+++ b/packages/wallet-adapter/_/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @solana/wallet-standard-wallet-adapter
 
+## 1.1.2-alpha.0
+
+### Patch Changes
+
+-   @solana/wallet-standard-wallet-adapter-base@1.1.2-alpha.0
+-   @solana/wallet-standard-wallet-adapter-react@1.1.2-alpha.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/wallet-adapter/_/package.json
+++ b/packages/wallet-adapter/_/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter",
-    "version": "1.1.1",
+    "version": "1.1.2-alpha.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/base/CHANGELOG.md
+++ b/packages/wallet-adapter/base/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @solana/wallet-standard-wallet-adapter-base
 
+## 1.1.2-alpha.0
+
+### Patch Changes
+
+-   Updated dependencies
+    -   @solana/wallet-standard-features@1.2.0-alpha.0
+    -   @solana/wallet-standard-util@1.1.1-alpha.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/wallet-adapter/base/package.json
+++ b/packages/wallet-adapter/base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter-base",
-    "version": "1.1.1",
+    "version": "1.1.2-alpha.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallet-adapter/react/CHANGELOG.md
+++ b/packages/wallet-adapter/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @solana/wallet-standard-wallet-adapter-react
 
+## 1.1.2-alpha.0
+
+### Patch Changes
+
+-   @solana/wallet-standard-wallet-adapter-base@1.1.2-alpha.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/wallet-adapter/react/package.json
+++ b/packages/wallet-adapter/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-standard-wallet-adapter-react",
-    "version": "1.1.1",
+    "version": "1.1.2-alpha.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/wallets/ghost/package.json
+++ b/packages/wallets/ghost/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@solana/wallet-standard-ghost",
-    "version": "0.1.0",
+    "version": "0.1.1-alpha.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",
@@ -26,7 +26,7 @@
         "build": "npm run clean && npm run tsc && npm run package"
     },
     "dependencies": {
-        "@solana/wallet-standard-features": "^1.1.0",
+        "@solana/wallet-standard-features": "^1.2.0-alpha.0",
         "@solana/web3.js": "^1.58.0",
         "@wallet-standard/base": "^1.0.1",
         "@wallet-standard/features": "^1.0.3",


### PR DESCRIPTION
This PR adds `waitForCommitmentToSendNextTransaction` to `SolanaSignAndSendTransactionOptions`.

This is to support serial transaction submission using `solana:signAndSendTransaction`.
* `waitForCommitmentToSendNextTransaction` helps wallets understand if a given transaction should be sent serially or concurrently
* if it is `false`, wallets don’t wait for confirmation, and it acts as concurrent. if `true`, wallets wait and it acts as serial.
