### PR TITLE
add `sendMode` to SendTransactionOptions

### DIFF
--- a/packages/core/features/src/signAndSendTransaction.ts
+++ b/packages/core/features/src/signAndSendTransaction.ts
@@ -63,4 +63,10 @@ export type SolanaSignAndSendTransactionOptions = SolanaSignTransactionOptions &
 
     /** Maximum number of times for the RPC node to retry sending the transaction to the leader. */
     readonly maxRetries?: number;
+
+    /** Submission mode of transactions. Needs to be set for the first transaction of SolanaSignAndSendTransactionInput[] */
+    readonly sendMode?: SolanaTransactionSendMode;
 };
+
+/** Submission mode of signed transactions. Concurrent by default. */
+export type SolanaTransactionSendMode = 'concurrent' | 'serial';


### PR DESCRIPTION
This PR adds a `sendMode` to `SolanaSignAndSendTransactionOptions`. 

This allows support for serial submission of transactions by wallets using the `SolanaSignAndSendTransaction` feature.