### PR TITLE
add send mode to signAndSendTransaction

### DIFF
--- a/.changeset/witty-mails-travel.md
+++ b/.changeset/witty-mails-travel.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-standard-features': minor
+---
+
+Add `mode` option to `signAndSendTransaction` input

--- a/packages/core/features/src/signAndSendTransaction.ts
+++ b/packages/core/features/src/signAndSendTransaction.ts
@@ -63,4 +63,10 @@ export type SolanaSignAndSendTransactionOptions = SolanaSignTransactionOptions &
 
     /** Maximum number of times for the RPC node to retry sending the transaction to the leader. */
     readonly maxRetries?: number;
+
+    /** Submission mode of transactions. Needs to be set for the first transaction of SolanaSignAndSendTransactionInput[] */
+    readonly sendMode?: SolanaTransactionSendMode;
 };
+
+/** Submission mode of signed transactions. Concurrent by default. */
+export type SolanaTransactionSendMode = 'concurrent' | 'serial';

--- a/packages/core/features/src/signAndSendTransaction.ts
+++ b/packages/core/features/src/signAndSendTransaction.ts
@@ -55,6 +55,9 @@ export interface SolanaSignAndSendTransactionOutput {
 
 /** Options for signing and sending a transaction. */
 export type SolanaSignAndSendTransactionOptions = SolanaSignTransactionOptions & {
+    /** Mode for signing and sending transactions. */
+    readonly mode?: SolanaSignAndSendTransactionMode;
+
     /** Desired commitment level. If provided, confirm the transaction after sending. */
     readonly commitment?: SolanaTransactionCommitment;
 
@@ -63,10 +66,7 @@ export type SolanaSignAndSendTransactionOptions = SolanaSignTransactionOptions &
 
     /** Maximum number of times for the RPC node to retry sending the transaction to the leader. */
     readonly maxRetries?: number;
-
-    /** Submission mode of transactions. Needs to be set for the first transaction of SolanaSignAndSendTransactionInput[] */
-    readonly sendMode?: SolanaTransactionSendMode;
 };
 
-/** Submission mode of signed transactions. Concurrent by default. */
-export type SolanaTransactionSendMode = 'concurrent' | 'serial';
+/** Mode for signing and sending transactions. */
+export type SolanaSignAndSendTransactionMode = 'parallel' | 'serial';


### PR DESCRIPTION
This PR adds a sendMode to `SolanaSignAndSendTransactionOptions`.

This allows support for serial submission of transactions by wallets using the `SolanaSignAndSendTransaction` feature.