### PR TITLE
Unregister listener in `useStandardWalletAdapters` doing the opposite filtering

### DIFF
--- a/packages/wallet-adapter/react/src/useStandardWalletAdapters.ts
+++ b/packages/wallet-adapter/react/src/useStandardWalletAdapters.ts
@@ -17,7 +17,7 @@ export function useStandardWalletAdapters(adapters: Adapter[]): Adapter[] {
             on('unregister', (...wallets) =>
                 setStandardAdapters((standardAdapters) =>
                     standardAdapters.filter((standardAdapter) =>
-                        wallets.some((wallet) => wallet === standardAdapter.wallet)
+                        wallets.some((wallet) => wallet !== standardAdapter.wallet)
                     )
                 )
             ),


### PR DESCRIPTION
When unregistering a wallet, it seems to remove all wallets except for the one I tried to unregister in useStandardWalletAdapters. Updating the filter in `unregister` to do the opposite of what it's filtering now