### PR TITLE
Add solana:signOffchainMessage feature

### DIFF
--- a/.changeset/sign-offchain-message-feature.md
+++ b/.changeset/sign-offchain-message-feature.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-standard-features': minor
+---
+
+Add the `solana:signOffchainMessage` feature, allowing dapps to request that a wallet sign offchain messages conforming to the Solana offchain message signing specification.

--- a/packages/core/features/src/__typetests__/signOffchainMessage-typetest.ts
+++ b/packages/core/features/src/__typetests__/signOffchainMessage-typetest.ts
@@ -1,0 +1,146 @@
+import type { ReadonlyUint8Array, WalletAccount } from '@wallet-standard/base';
+
+import type {
+    SolanaOffchainMessageVersion,
+    SolanaSignOffchainMessageFeature,
+    SolanaSignOffchainMessageInput,
+    SolanaSignOffchainMessageInputV1,
+    SolanaSignOffchainMessageMethod,
+    SolanaSignOffchainMessageOutput,
+    SolanaSignOffchainMessageVersion,
+} from '../signOffchainMessage.js';
+
+const account = null as unknown as WalletAccount;
+
+// [DESCRIBE] `SolanaSignOffchainMessageInput`
+{
+    // The only input variant is currently the version 1 input.
+    {
+        const input = null as unknown as SolanaSignOffchainMessageInput;
+        input satisfies SolanaSignOffchainMessageInputV1;
+    }
+}
+
+// [DESCRIBE] `SolanaSignOffchainMessageInputV1`
+{
+    // A fully specified version 1 input satisfies the type.
+    {
+        ({
+            account,
+            message: new Uint8Array(),
+            messageVersion: 1,
+            requiredSigners: [new Uint8Array()],
+        }) satisfies SolanaSignOffchainMessageInputV1;
+    }
+
+    // The `messageVersion` must be exactly `1`.
+    {
+        // @ts-expect-error Version 0 is not a supported message version.
+        0 satisfies SolanaSignOffchainMessageInputV1['messageVersion'];
+    }
+}
+
+// [DESCRIBE] `requiredSigners` ergonomics with `WalletAccount`
+{
+    // It accepts the public key of a `WalletAccount` directly, without casting.
+    // `WalletAccount['publicKey']` is a `ReadonlyUint8Array`, so requiring `Uint8Array` here would
+    // force callers to cast.
+    {
+        ({
+            account,
+            message: new Uint8Array(),
+            messageVersion: 1,
+            requiredSigners: [account.publicKey],
+        }) satisfies SolanaSignOffchainMessageInputV1;
+    }
+
+    // It accepts an array of `WalletAccount` public keys built with `.map()`, without casting.
+    // A plain array (rather than a non-empty tuple) means `.map()` results need no `as [...]` cast.
+    {
+        const accounts = null as unknown as WalletAccount[];
+        const requiredSigners = accounts.map((a) => a.publicKey);
+        requiredSigners satisfies SolanaSignOffchainMessageInputV1['requiredSigners'];
+    }
+
+    // Its elements are `ReadonlyUint8Array` (the same type as `WalletAccount['publicKey']`).
+    {
+        const element = null as unknown as SolanaSignOffchainMessageInputV1['requiredSigners'][number];
+        element satisfies ReadonlyUint8Array;
+        element satisfies WalletAccount['publicKey'];
+    }
+
+    // It rejects values that are not byte arrays.
+    {
+        // @ts-expect-error A list of strings is not a list of public keys.
+        const requiredSigners: SolanaSignOffchainMessageInputV1['requiredSigners'] = ['not a public key'];
+    }
+}
+
+// [DESCRIBE] `SolanaSignOffchainMessageOutput`
+{
+    // A minimal output satisfies the type.
+    {
+        ({
+            signature: new Uint8Array(),
+            signedOffchainMessage: new Uint8Array(),
+        }) satisfies SolanaSignOffchainMessageOutput;
+    }
+
+    // `signatureType`, when present, must be `'ed25519'`.
+    {
+        ({
+            signature: new Uint8Array(),
+            signatureType: 'ed25519',
+            signedOffchainMessage: new Uint8Array(),
+        }) satisfies SolanaSignOffchainMessageOutput;
+
+        ({
+            signature: new Uint8Array(),
+            // @ts-expect-error Only `'ed25519'` is a supported signature type.
+            signatureType: 'secp256k1',
+            signedOffchainMessage: new Uint8Array(),
+        }) satisfies SolanaSignOffchainMessageOutput;
+    }
+}
+
+// [DESCRIBE] `SolanaSignOffchainMessageMethod`
+{
+    // It is variadic over inputs and resolves to a list of outputs.
+    {
+        const signOffchainMessage = null as unknown as SolanaSignOffchainMessageMethod;
+        const input = null as unknown as SolanaSignOffchainMessageInput;
+        signOffchainMessage(input, input) satisfies Promise<readonly SolanaSignOffchainMessageOutput[]>;
+    }
+}
+
+// [DESCRIBE] `SolanaSignOffchainMessageFeature`
+{
+    // The feature is keyed by the `solana:signOffchainMessage` identifier.
+    {
+        const feature = null as unknown as SolanaSignOffchainMessageFeature;
+        feature['solana:signOffchainMessage'].version satisfies SolanaSignOffchainMessageVersion;
+        feature['solana:signOffchainMessage']
+            .supportedMessageVersions satisfies readonly SolanaOffchainMessageVersion[];
+        feature['solana:signOffchainMessage'].signOffchainMessage satisfies SolanaSignOffchainMessageMethod;
+    }
+}
+
+// [DESCRIBE] `SolanaSignOffchainMessageVersion`
+{
+    // The current feature API version is `'1.0.0'`.
+    {
+        '1.0.0' satisfies SolanaSignOffchainMessageVersion;
+        // @ts-expect-error `'2.0.0'` is not a supported feature API version.
+        '2.0.0' satisfies SolanaSignOffchainMessageVersion;
+    }
+}
+
+// [DESCRIBE] `SolanaOffchainMessageVersion`
+{
+    // The only supported offchain message specification version is `1`.
+    {
+        1 satisfies SolanaOffchainMessageVersion;
+        // @ts-expect-error `0` is not a supported offchain message specification version.
+        0 satisfies SolanaOffchainMessageVersion;
+    }
+}

--- a/packages/core/features/src/__typetests__/signOffchainMessage-typetest.ts
+++ b/packages/core/features/src/__typetests__/signOffchainMessage-typetest.ts
@@ -27,7 +27,7 @@ const account = null as unknown as WalletAccount;
     {
         ({
             account,
-            message: new Uint8Array(),
+            message: "",
             messageVersion: 1,
             requiredSigners: [new Uint8Array()],
         }) satisfies SolanaSignOffchainMessageInputV1;
@@ -38,9 +38,6 @@ const account = null as unknown as WalletAccount;
         // @ts-expect-error Version 0 is not a supported message version.
         0 satisfies SolanaSignOffchainMessageInputV1['messageVersion'];
     }
-
-    // The `message` can be readonly
-    null as unknown as ReadonlyUint8Array satisfies SolanaSignOffchainMessageInputV1['message'];
 }
 
 // [DESCRIBE] `requiredSigners` ergonomics with `WalletAccount`
@@ -51,7 +48,7 @@ const account = null as unknown as WalletAccount;
     {
         ({
             account,
-            message: new Uint8Array(),
+            message: "",
             messageVersion: 1,
             requiredSigners: [account.publicKey],
         }) satisfies SolanaSignOffchainMessageInputV1;

--- a/packages/core/features/src/__typetests__/signOffchainMessage-typetest.ts
+++ b/packages/core/features/src/__typetests__/signOffchainMessage-typetest.ts
@@ -38,6 +38,9 @@ const account = null as unknown as WalletAccount;
         // @ts-expect-error Version 0 is not a supported message version.
         0 satisfies SolanaSignOffchainMessageInputV1['messageVersion'];
     }
+
+    // The `message` can be readonly
+    null as unknown as ReadonlyUint8Array satisfies SolanaSignOffchainMessageInputV1['message'];
 }
 
 // [DESCRIBE] `requiredSigners` ergonomics with `WalletAccount`
@@ -100,6 +103,16 @@ const account = null as unknown as WalletAccount;
             signatureType: 'secp256k1',
             signedOffchainMessage: new Uint8Array(),
         }) satisfies SolanaSignOffchainMessageOutput;
+    }
+
+    // The `signature` can be readonly.
+    {
+        null as unknown as ReadonlyUint8Array satisfies SolanaSignOffchainMessageOutput['signature'];
+    }
+
+    // The `signedOffchainMessage` can be readonly.
+    {
+        null as unknown as ReadonlyUint8Array satisfies SolanaSignOffchainMessageOutput['signedOffchainMessage'];
     }
 }
 

--- a/packages/core/features/src/index.ts
+++ b/packages/core/features/src/index.ts
@@ -4,6 +4,7 @@ import type { SolanaSignInFeature } from './signIn.js';
 import type { SolanaSignMessageFeature } from './signMessage.js';
 import type { SolanaSignTransactionFeature } from './signTransaction.js';
 import type { SolanaSignAndSendAllTransactionsFeature } from './signAndSendAllTransactions.js';
+import type { SolanaSignOffchainMessageFeature } from './signOffchainMessage.js';
 
 /** TODO: docs */
 export type SolanaFeatures =
@@ -11,7 +12,8 @@ export type SolanaFeatures =
     | SolanaSignInFeature
     | SolanaSignMessageFeature
     | SolanaSignTransactionFeature
-    | SolanaSignAndSendAllTransactionsFeature;
+    | SolanaSignAndSendAllTransactionsFeature
+    | SolanaSignOffchainMessageFeature;
 
 /** TODO: docs */
 export type WalletWithSolanaFeatures = WalletWithFeatures<SolanaFeatures>;
@@ -21,3 +23,4 @@ export * from './signIn.js';
 export * from './signMessage.js';
 export * from './signTransaction.js';
 export * from './signAndSendAllTransactions.js';
+export * from './signOffchainMessage.js';

--- a/packages/core/features/src/signOffchainMessage.ts
+++ b/packages/core/features/src/signOffchainMessage.ts
@@ -80,7 +80,7 @@ export interface SolanaSignOffchainMessageInputV1 {
      * canonical preamble required by the specification.
      * Must be non-empty and must contain the public key of `account`.
      */
-    readonly requiredSigners: readonly [Uint8Array, ...(readonly Uint8Array[])];
+    readonly requiredSigners: readonly WalletAccount['publicKey'][];
 }
 
 /** Output of signing an offchain message. */

--- a/packages/core/features/src/signOffchainMessage.ts
+++ b/packages/core/features/src/signOffchainMessage.ts
@@ -69,10 +69,10 @@ export interface SolanaSignOffchainMessageInputV1 {
     readonly account: WalletAccount;
 
     /**
-     * UTF-8 message body, as raw bytes.
-     * The wallet must reject byte sequences that are not valid UTF-8.
+     * UTF-8 message body, as string.
+     * The wallet must encode this as UTF-8 using the [WHATWG TextEncoder Standard](https://encoding.spec.whatwg.org/#interface-textencoder)
      */
-    readonly message: ReadonlyUint8Array;
+    readonly message: string;
 
     /**
      * Required signer public keys, 32 bytes each.

--- a/packages/core/features/src/signOffchainMessage.ts
+++ b/packages/core/features/src/signOffchainMessage.ts
@@ -37,7 +37,7 @@ export type SolanaSignOffchainMessageFeature = {
 export type SolanaSignOffchainMessageVersion = '1.0.0';
 
 /** Offchain message specification version. */
-export type SolanaOffchainMessageVersion = 0 | 1;
+export type SolanaOffchainMessageVersion = 1;
 
 /**
  * Signs one or more offchain messages, returning for each the full bytes the wallet constructed and signed
@@ -55,45 +55,7 @@ export type SolanaSignOffchainMessageMethod = (
  * Input for signing an offchain message.
  * Discriminated on `messageVersion` to enforce version-specific fields at the type level.
  */
-export type SolanaSignOffchainMessageInput = SolanaSignOffchainMessageInputV0 | SolanaSignOffchainMessageInputV1;
-
-/** Input for signing a version 0 offchain message. */
-export interface SolanaSignOffchainMessageInputV0 {
-    /** Offchain message specification version. */
-    readonly messageVersion: 0;
-
-    /**
-     * Account to use.
-     * Its public key must appear in `requiredSigners`.
-     */
-    readonly account: WalletAccount;
-
-    /**
-     * 32-byte application identifier.
-     * Wallets should render this to the user as a base58 string.
-     */
-    readonly applicationDomain: Uint8Array;
-
-    /**
-     * Body encoding and length variant:
-     * - `0` — restricted ASCII (`0x20..=0x7e`), at most 1232 bytes of preamble and body combined.
-     * - `1` — UTF-8, at most 1232 bytes combined.
-     * - `2` — UTF-8, at most 65535 bytes combined.
-     *
-     * The wallet must validate `message` against the chosen format and reject it otherwise.
-     */
-    readonly messageFormat: 0 | 1 | 2;
-
-    /** Message body, as raw bytes. */
-    readonly message: Uint8Array;
-
-    /**
-     * Required signer public keys, 32 bytes each.
-     * Order is preserved in the preamble.
-     * Must be non-empty and must contain the public key of `account`.
-     */
-    readonly requiredSigners: readonly [Uint8Array, ...(readonly Uint8Array[])];
-}
+export type SolanaSignOffchainMessageInput = SolanaSignOffchainMessageInputV1;
 
 /** Input for signing a version 1 offchain message. */
 export interface SolanaSignOffchainMessageInputV1 {

--- a/packages/core/features/src/signOffchainMessage.ts
+++ b/packages/core/features/src/signOffchainMessage.ts
@@ -1,4 +1,4 @@
-import type { WalletAccount } from '@wallet-standard/base';
+import type { ReadonlyUint8Array, WalletAccount } from '@wallet-standard/base';
 
 /** Name of the feature. */
 export const SolanaSignOffchainMessage = 'solana:signOffchainMessage';
@@ -72,7 +72,7 @@ export interface SolanaSignOffchainMessageInputV1 {
      * UTF-8 message body, as raw bytes.
      * The wallet must reject byte sequences that are not valid UTF-8.
      */
-    readonly message: Uint8Array;
+    readonly message: ReadonlyUint8Array;
 
     /**
      * Required signer public keys, 32 bytes each.
@@ -89,13 +89,13 @@ export interface SolanaSignOffchainMessageOutput {
      * Full preamble and body bytes that the wallet constructed and signed.
      * Returned verbatim so the verifier can validate the signature without rebuilding the preamble.
      */
-    readonly signedOffchainMessage: Uint8Array;
+    readonly signedOffchainMessage: ReadonlyUint8Array;
 
     /**
      * Message signature produced.
      * If the signature type is provided, the signature must be Ed25519.
      */
-    readonly signature: Uint8Array;
+    readonly signature: ReadonlyUint8Array;
 
     /**
      * Optional type of the message signature produced.

--- a/packages/core/features/src/signOffchainMessage.ts
+++ b/packages/core/features/src/signOffchainMessage.ts
@@ -1,0 +1,143 @@
+import type { WalletAccount } from '@wallet-standard/base';
+
+/** Name of the feature. */
+export const SolanaSignOffchainMessage = 'solana:signOffchainMessage';
+
+/**
+ * `solana:signOffchainMessage` is a feature that may be implemented by a {@link "@wallet-standard/base".Wallet}
+ * to allow a dapp to request the wallet to sign offchain messages conforming to the Solana offchain message
+ * signing specification (https://github.com/solana-foundation/SRFCs/discussions/3).
+ */
+export type SolanaSignOffchainMessageFeature = {
+    /** Name of the feature. */
+    readonly [SolanaSignOffchainMessage]: {
+        /** Version of the feature API. */
+        readonly version: SolanaSignOffchainMessageVersion;
+
+        /**
+         * Offchain message specification versions this wallet can serialize and sign.
+         * See https://github.com/solana-foundation/SRFCs/discussions/3.
+         */
+        readonly supportedMessageVersions: readonly SolanaOffchainMessageVersion[];
+
+        /**
+         * Sign offchain messages using the account's secret key, conforming to the Solana offchain
+         * message signing specification (https://github.com/solana-foundation/SRFCs/discussions/3).
+         *
+         * @param inputs Offchain messages to sign.
+         *
+         * @return Results of signing offchain messages. For each message this includes the full
+         * bytes the wallet constructed and signed along with the resulting signature.
+         */
+        readonly signOffchainMessage: SolanaSignOffchainMessageMethod;
+    };
+};
+
+/** Version of the feature. */
+export type SolanaSignOffchainMessageVersion = '1.0.0';
+
+/** Offchain message specification version. */
+export type SolanaOffchainMessageVersion = 0 | 1;
+
+/**
+ * Signs one or more offchain messages, returning for each the full bytes the wallet constructed and signed
+ * along with the resulting signature.
+ *
+ * @param inputs Offchain messages to sign.
+ *
+ * @return Results of signing offchain messages.
+ */
+export type SolanaSignOffchainMessageMethod = (
+    ...inputs: readonly SolanaSignOffchainMessageInput[]
+) => Promise<readonly SolanaSignOffchainMessageOutput[]>;
+
+/**
+ * Input for signing an offchain message.
+ * Discriminated on `messageVersion` to enforce version-specific fields at the type level.
+ */
+export type SolanaSignOffchainMessageInput = SolanaSignOffchainMessageInputV0 | SolanaSignOffchainMessageInputV1;
+
+/** Input for signing a version 0 offchain message. */
+export interface SolanaSignOffchainMessageInputV0 {
+    /** Offchain message specification version. */
+    readonly messageVersion: 0;
+
+    /**
+     * Account to use.
+     * Its public key must appear in `requiredSigners`.
+     */
+    readonly account: WalletAccount;
+
+    /**
+     * 32-byte application identifier.
+     * Wallets should render this to the user as a base58 string.
+     */
+    readonly applicationDomain: Uint8Array;
+
+    /**
+     * Body encoding and length variant:
+     * - `0` — restricted ASCII (`0x20..=0x7e`), at most 1232 bytes of preamble and body combined.
+     * - `1` — UTF-8, at most 1232 bytes combined.
+     * - `2` — UTF-8, at most 65535 bytes combined.
+     *
+     * The wallet must validate `message` against the chosen format and reject it otherwise.
+     */
+    readonly messageFormat: 0 | 1 | 2;
+
+    /** Message body, as raw bytes. */
+    readonly message: Uint8Array;
+
+    /**
+     * Required signer public keys, 32 bytes each.
+     * Order is preserved in the preamble.
+     * Must be non-empty and must contain the public key of `account`.
+     */
+    readonly requiredSigners: readonly [Uint8Array, ...(readonly Uint8Array[])];
+}
+
+/** Input for signing a version 1 offchain message. */
+export interface SolanaSignOffchainMessageInputV1 {
+    /** Offchain message specification version. */
+    readonly messageVersion: 1;
+
+    /**
+     * Account to use.
+     * Its public key must appear in `requiredSigners`.
+     */
+    readonly account: WalletAccount;
+
+    /**
+     * UTF-8 message body, as raw bytes.
+     * The wallet must reject byte sequences that are not valid UTF-8.
+     */
+    readonly message: Uint8Array;
+
+    /**
+     * Required signer public keys, 32 bytes each.
+     * The wallet sorts these lexicographically and rejects duplicates internally to produce the
+     * canonical preamble required by the specification.
+     * Must be non-empty and must contain the public key of `account`.
+     */
+    readonly requiredSigners: readonly [Uint8Array, ...(readonly Uint8Array[])];
+}
+
+/** Output of signing an offchain message. */
+export interface SolanaSignOffchainMessageOutput {
+    /**
+     * Full preamble and body bytes that the wallet constructed and signed.
+     * Returned verbatim so the verifier can validate the signature without rebuilding the preamble.
+     */
+    readonly signedOffchainMessage: Uint8Array;
+
+    /**
+     * Message signature produced.
+     * If the signature type is provided, the signature must be Ed25519.
+     */
+    readonly signature: Uint8Array;
+
+    /**
+     * Optional type of the message signature produced.
+     * If not provided, the signature must be Ed25519.
+     */
+    readonly signatureType?: 'ed25519';
+}

--- a/packages/core/features/tsconfig.all.json
+++ b/packages/core/features/tsconfig.all.json
@@ -6,6 +6,9 @@
         },
         {
             "path": "./tsconfig.esm.json"
+        },
+        {
+            "path": "./tsconfig.tests.json"
         }
     ]
 }

--- a/packages/core/features/tsconfig.cjs.json
+++ b/packages/core/features/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../tsconfig.cjs.json",
     "include": ["src"],
+    "exclude": ["src/**/__typetests__"],
     "compilerOptions": {
         "outDir": "lib/cjs"
     }

--- a/packages/core/features/tsconfig.esm.json
+++ b/packages/core/features/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../tsconfig.esm.json",
     "include": ["src"],
+    "exclude": ["src/**/__typetests__"],
     "compilerOptions": {
         "outDir": "lib/esm",
         "declarationDir": "lib/types"

--- a/packages/core/features/tsconfig.tests.json
+++ b/packages/core/features/tsconfig.tests.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../../tsconfig.tests.json",
+    "include": ["src"]
+}


### PR DESCRIPTION
See https://www.notion.so/solanafoundation/Solana-Off-Chain-Message-Signing-OCMS-374d36dad52d80bf981ddbcebfeca5f0

This PR adds a new `solana:signOffchainMessage` feature, which allows apps to request offchain message signing.

There are two specified versions of offchain messages, [v0](https://github.com/anza-xyz/agave/blob/master/docs/src/proposals/off-chain-message-signing.md) and [v1](https://github.com/solana-foundation/SRFCs/discussions/3). This feature only supports v1, as mentioned in the above document.

Wallets specify their support with the feature definition:

```ts
const feature: SolanaSignOffchainMessageFeature = {
    'solana:signOffchainMessage': {
        version: '1.0.0',

        // offchain message spec versions this wallet can serialize and sign
        supportedMessageVersions: [1],

        // (...inputs) => Promise<readonly SolanaSignOffchainMessageOutput[]>
        signOffchainMessage: async (...inputs) => {
            // implementation omitted
        },
    },
};
```

Example v1 input:

```ts
const inputV1: SolanaSignOffchainMessageInputV1 = {
    messageVersion: 1,
    account, // a WalletAccount whose publicKey is in requiredSigners

    // UTF-8 message body bytes (wallet rejects invalid UTF-8)
    message: new TextEncoder().encode('Hello from the dapp!'),

    // wallet sorts these lexicographically and rejects duplicates internally;
    // must contain account.publicKey
    requiredSigners: [account.publicKey, otherSignerPublicKey],
};
```

Each `SolanaSignOffchainMessageOutput` is:

```ts
{
    signedOffchainMessage: Uint8Array, // full preamble + body the wallet signed
    signature: Uint8Array,             // Ed25519 signature
    signatureType?: 'ed25519',         // optional; Ed25519 if omitted
}
```

An implementation of the offchain-messages spec (types/codecs) is available as part of [`@solana/offchain-messages`](https://github.com/anza-xyz/kit/tree/main/packages/offchain-messages )