### PR TITLE
Add a version 1.1.0 of SIWS feature to support offchain messages

### DIFF
--- a/packages/core/features/src/signIn.ts
+++ b/packages/core/features/src/signIn.ts
@@ -130,8 +130,19 @@ export interface SolanaSignInOutput {
      * If not provided, the signature must be Ed25519.
      */
     readonly signatureType?: 'ed25519';
+
+    /**
+     * Optional format of the message that was signed.
+     * If not provided, the message format is not specified.
+     */
+    readonly signedMessageFormat?: SignedMessageFormat;
 }
 
 type OffchainMessageConfig = {
+    messageVersion: 1;
+};
+
+type SignedMessageFormat = {
+    kind: 'offchainMessage';
     messageVersion: 1;
 };

--- a/packages/core/features/src/signIn.ts
+++ b/packages/core/features/src/signIn.ts
@@ -16,7 +16,9 @@ export type SolanaSignInFeature = {
 };
 
 /** Version of the feature. */
-export type SolanaSignInVersion = '1.0.0';
+// Note: version 1.1.0 adds support for offchain messages, so wallets supporting that version must support the
+// `useOffchainMessage` option in the input of the `signIn` method.
+export type SolanaSignInVersion = '1.0.0' | '1.1.0';
 
 /** TODO: docs */
 export type SolanaSignInMethod = (...inputs: readonly SolanaSignInInput[]) => Promise<readonly SolanaSignInOutput[]>;
@@ -94,6 +96,13 @@ export interface SolanaSignInInput {
      * If not provided, the wallet must not include Resources in the message.
      */
     readonly resources?: readonly string[];
+
+    /**
+     * Optional configuration for using offchain messages.
+     * If provided, the wallet must use an offchain message for signing in instead of an onchain message.
+     * Note that only wallets advertising version: 1.1.0 or later of the feature support this option.
+     */
+    readonly useOffchainMessage?: OffchainMessageConfig;
 }
 
 /** Output of signing in. */
@@ -122,3 +131,7 @@ export interface SolanaSignInOutput {
      */
     readonly signatureType?: 'ed25519';
 }
+
+type OffchainMessageConfig = {
+    messageVersion: 1;
+};


### PR DESCRIPTION
This PR includes a proposed update to the `solana:signIn` feature to support offchain messages

More about offchain messages, and the proposed `signOffchainMessage` feature can be found at #92. This PR is not dependent on that in wallet-standard, but would share much of the implementation in wallets.

The goal here is to make our `signIn` feature work with hardware wallets, in the same way `signOffchainMessage` does.

My suggested approach is:

- Extend `SolanaSignInInput` with a new `useOffchainMessage?: OffchainMessageConfig`
- Currently this config is just `{ messageVersion: 1 }`, but it could also be updated to support future versions off the offchain message spec
- Wallets advertise support for this by bumping their version of the feature to `1.1.0`

Existing apps will continue working, with the current limitation of not supporting hardware wallets for `signIn`. If a wallet advertises version `1.1.0` of the feature, an app will be able to update their call to `solana:signIn` to add `useOffchainMessage`. If they do so, the wallet must return the SIWS message in an offchain message envelope. The content will be the SIWS message (which is ASCII), and `requiredSigners` will be just the account that has been signed in.

This should provide support for offchain messages, and therefore hardware wallet signers, in SIWS.