### PR TITLE
fix: remove unregistered Wallet Standard adapters

### DIFF
--- a/.changeset/fix-wallet-adapter-unregister.md
+++ b/.changeset/fix-wallet-adapter-unregister.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-standard-wallet-adapter-react': patch
+---
+
+Remove unregistered Wallet Standard adapters.

--- a/packages/wallet-adapter/react/src/useStandardWalletAdapters.ts
+++ b/packages/wallet-adapter/react/src/useStandardWalletAdapters.ts
@@ -17,7 +17,7 @@ export function useStandardWalletAdapters(adapters: Adapter[]): Adapter[] {
             on('unregister', (...wallets) =>
                 setStandardAdapters((standardAdapters) =>
                     standardAdapters.filter((standardAdapter) =>
-                        wallets.some((wallet) => wallet === standardAdapter.wallet)
+                        wallets.every((wallet) => wallet !== standardAdapter.wallet)
                     )
                 )
             ),

--- a/packages/wallet-adapter/react/src/useStandardWalletAdapters.ts
+++ b/packages/wallet-adapter/react/src/useStandardWalletAdapters.ts
@@ -17,7 +17,7 @@ export function useStandardWalletAdapters(adapters: Adapter[]): Adapter[] {
             on('unregister', (...wallets) =>
                 setStandardAdapters((standardAdapters) =>
                     standardAdapters.filter((standardAdapter) =>
-                        wallets.every((wallet) => wallet !== standardAdapter.wallet)
+                        !wallets.includes(standardAdapter.wallet)
                     )
                 )
             ),


### PR DESCRIPTION
Fixes #44.

The unregister listener has its filter backwards: it keeps the wallet adapters being unregistered and drops unrelated ones. With multiple Wallet Standard wallets registered, that can leave stale adapters behind and make valid wallets disappear.

This changes the filter to keep an adapter only when its wallet is not included in the unregister event. Using `every` also handles events that unregister more than one wallet at once.

Includes a patch changeset for `@solana/wallet-standard-wallet-adapter-react`.

Checked with `pnpm run build`, `pnpm test`, and focused Prettier and ESLint checks.
