### PR TITLE
fix(wallet-adapter): rebuild the account only when it changed

### DIFF
--- a/packages/wallet-adapter/base/src/wallet.ts
+++ b/packages/wallet-adapter/base/src/wallet.ts
@@ -209,7 +209,7 @@ export class SolanaWalletAdapterWallet implements Wallet {
             if (
                 !account ||
                 account.address !== address ||
-                account.chains.includes(this.#chain) ||
+                !account.chains.includes(this.#chain) ||
                 !bytesEqual(account.publicKey, publicKey)
             ) {
                 this.#account = new SolanaWalletAdapterWalletAccount({


### PR DESCRIPTION
## What

`SolanaWalletAdapterWallet.#connected()` rebuilds the account and emits a `change` event on every connect, even when nothing changed, because the chain clause in its guard is not negated.

## Why

The guard is a set of "did something change" predicates:

```ts
if (
    !account ||
    account.address !== address ||
    account.chains.includes(this.#chain) ||
    !bytesEqual(account.publicKey, publicKey)
) {
    this.#account = new SolanaWalletAdapterWalletAccount({ ..., chains: [this.#chain] });
    this.#emit('change', { accounts: this.accounts });
}
```

Every account this class creates is constructed with `chains: [this.#chain]`, and `#chain` is fixed at construction, so `account.chains.includes(this.#chain)` is always `true`. The whole condition is therefore always true, so `#connected()` (which runs on construction and on every reconnect) creates a fresh `SolanaWalletAdapterWalletAccount` and emits a redundant `change` every time, even when the address and public key are unchanged.

Because the account object identity changes, any account reference a dApp is holding no longer equals `this.#account`, so the next `signTransaction` / `signMessage` / `signAndSendTransaction` / `signIn` call fails the `input.account !== this.#account` guard and throws `invalid account` for a legitimate, same-key signer.

The sibling `GhostWallet.#connected` (`packages/wallets/ghost/src/wallet.ts`) uses only negated difference checks (`!account || account.address !== address || !bytesEqual(...)`), with no positive `chains.includes` term, so it does not churn the account on reconnect.

## Change

Negate the chain clause (`!account.chains.includes(this.#chain)`), so the account is rebuilt only when it is missing, the address changed, the chain is genuinely absent, or the public key changed. A benign reconnect now keeps the same account object and emits no redundant `change`, matching the sibling wallet.
